### PR TITLE
Add Product Grid Item and Product Grid

### DIFF
--- a/theme/locales/en.default.json
+++ b/theme/locales/en.default.json
@@ -37,6 +37,11 @@
           "text": "Instagram"
         }
       }
+    },
+    "product_grid_item": {
+      "product_btn": {
+        "aria_label": "Navigate to the product page."
+      }
     }
   }
 }

--- a/theme/snippets/home-header.liquid
+++ b/theme/snippets/home-header.liquid
@@ -7,7 +7,7 @@
   <a href="/knowledege" target="_blank" rel="noreferrer noopener" aria-label="{{ 'snippets.home_header.links.knowledge_link.aria_label' | t }}">
     <span class="HomeHeader__button button--style-primary">{{ 'snippets.home_header.links.knowledge_link.text' | t }}</span>.
   </a>
-  <a href="/about" target="_blank" rel="noreferrer noopener" aria-label="{{ 'snippets.home_header.links.learn_more_link.aria_label' | t }}">
+  <a class="hover-lighten-black" href="/about" target="_blank" rel="noreferrer noopener" aria-label="{{ 'snippets.home_header.links.learn_more_link.aria_label' | t }}">
     {{ 'snippets.home_header.links.learn_more_link.text' | t }}
   </a>
 </div>

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -21,7 +21,7 @@
     {% endif %}
 
     <div class="ProductGridItem__image-container flex items-center justify-center absolute t0 r0 h100 w100">
-      <img class="ProductGridItem__image w100 h100 fit-contain" src="{{ product_media.src | img_url: 'x265' }}" alt="{{ product_media.alt | escape }}">
+      <img class="ProductGridItem__image w100 h100 fit-contain xs:py1" src="{{ product_media.src | img_url: 'x265' }}" alt="{{ product_media.alt | escape }}">
     </div>
 
     <div class="ProductGridItem__details absolute r0 b0 p_625 sans-xxs uppercase flex justify-between w100">

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -1,0 +1,24 @@
+{% comment %} TO-DO: Remove Type Design placeholder {% endcomment %}
+{% assign product_media = current_product.media | first %}
+{% if current_product.available == false %}
+  {% assign availability_text = 'Sold Out' %}
+{% endif %}
+
+<a class="ProductGridItem color-white text-decoration-none" href="{{ current_product.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
+  <div class="bg-color-black p_625">
+    <div class="flex justify-between">
+      <span class="ProductGridItem__title serif-xs uppercase">{{current_product.title}}</span>
+      <span class="ProductGridItem__price serif-xs uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
+    </div>
+    <span class="ProductGridItem__vendor sans-xs uppercase">{{current_product.vendor}}</span>
+    <img class="ProductGridItem__image w100 h100" src="{{ product_media.src | img_url: 'x265' }}" alt="{{ product_media.alt | escape }}">
+    <div class="sans-xxs uppercase flex justify-between">
+      <span class="flex items-center">
+        <span class="dot mr_25"></span>
+        <span>{{ current_product.type }}</span>
+      </span>
+      <span class="radius-xs border-white p_25">Type Design</span>
+    </div>
+  </div>
+  
+</a>

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -1,18 +1,19 @@
 {% comment %} TO-DO: Remove Type Design placeholder {% endcomment %}
 {% assign product_media = current_product.media | first %}
-{% if current_product.available == false %}
-  {% assign availability_text = 'Sold Out' %}
-{% endif %}
 
-<a class="debug ProductGridItem color-white text-decoration-none hover--style-rounded-border" href="{{ current_product.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
-  <div class="bg-color-black p_625">
+<a class="ProductGridItem bg-color-black color-white text-decoration-none hover--style-rounded-border relative p_625" href="{{ current_product.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
+  <div class="bg-color-black h100">
+    
     <div class="flex justify-between">
       <span class="ProductGridItem__title serif-xs uppercase">{{current_product.title}}</span>
       <span class="ProductGridItem__price serif-xs uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
     </div>
     <span class="ProductGridItem__vendor sans-xs uppercase">{{current_product.vendor}}</span>
-    <img class="ProductGridItem__image w100 h100" src="{{ product_media.src | img_url: 'x265' }}" alt="{{ product_media.alt | escape }}">
-    <div class="sans-xxs uppercase flex justify-between">
+    <div class="h1000 flex items-center justify-center">
+      <img class="ProductGridItem__image w100 h100 fit-contain" src="{{ product_media.src | img_url: 'x265' }}" alt="{{ product_media.alt | escape }}">
+    </div>
+
+    <div class="ProductGridItem__details absolute b0 r0 w100 sans-xxs uppercase flex justify-between p_625">
       <span class="flex items-center">
         <span class="dot mr_25"></span>
         <span>{{ current_product.type }}</span>
@@ -20,5 +21,14 @@
       <span class="radius-xs border-white p_25">Type Design</span>
     </div>
   </div>
-  
 </a>
+
+<!-- {% if current_product.metafields.accentuate.featured_product_text %}
+<span class="flex flex-col uppercase">
+  <span class="color-yellow serif-md">
+    {{ current_product.metafields.accentuate.featured_product_text }}
+  </span>
+<span class="ProductGridItem__title serif-md color-white">{{current_product.title}}</span>
+<span class="ProductGridItem__vendor sans-xs">{{current_product.vendor}}</span>
+</span>
+{% endif %} -->

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -4,7 +4,7 @@
   {% assign availability_text = 'Sold Out' %}
 {% endif %}
 
-<a class="ProductGridItem color-white text-decoration-none" href="{{ current_product.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
+<a class="debug ProductGridItem color-white text-decoration-none hover--style-rounded-border" href="{{ current_product.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
   <div class="bg-color-black p_625">
     <div class="flex justify-between">
       <span class="ProductGridItem__title serif-xs uppercase">{{current_product.title}}</span>

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -1,35 +1,10 @@
 {% comment %} TO-DO: Remove Type Design "Knowledge Area" placeholder {% endcomment %}
 {% assign product_media = current_product.media | first %}
 
-<!-- <a class="ProductGridItem bg-color-black color-white text-decoration-none hover--style-rounded-border relative p_625" href="{{ current_product.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
-  <div class="bg-color-black h100">
-    
-    <div class="flex justify-between">
-      <span class="ProductGridItem__title serif-xs uppercase">{{current_product.title}}</span>
-      <span class="ProductGridItem__price serif-xs uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
-    </div>
-    <span class="ProductGridItem__vendor sans-xs uppercase">{{current_product.vendor}}</span>
-    <div class="debug flex items-center justify-center">
-      <img class="ProductGridItem__image w100 h100 fit-contain" src="{{ product_media.src | img_url: 'x265' }}" alt="{{ product_media.alt | escape }}">
-    </div>
-
-    <div class="ProductGridItem__details sans-xxs uppercase flex justify-between">
-      <span class="flex items-center">
-        <span class="dot mr_25"></span>
-        <span>{{ current_product.type }}</span>
-      </span>
-      <span class="radius-xs border-white p_25">Type Design</span>
-    </div>
-  </div>
-</a> -->
-
-
-
-
 <a class="ProductGridItem bg-color-black color-white text-decoration-none hover--style-rounded-border relative p_625" href="{{ current_product.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
   <div class="ProductGridItem__inner-container bg-color-black h100">
-    
-    {% if current_product.metafields.accentuate.featured_product_text %}
+
+    {% if current_product.metafields.accentuate.featured_product_text and current_product.metafields.accentuate.is_featured_product and show_featured_product %}
       <span class="flex flex-col uppercase">
         <span class="color-yellow serif-md">
           {{ current_product.metafields.accentuate.featured_product_text }}

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -1,7 +1,7 @@
-{% comment %} TO-DO: Remove Type Design placeholder {% endcomment %}
+{% comment %} TO-DO: Remove Type Design "Knowledge Area" placeholder {% endcomment %}
 {% assign product_media = current_product.media | first %}
 
-<a class="ProductGridItem bg-color-black color-white text-decoration-none hover--style-rounded-border relative p_625" href="{{ current_product.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
+<!-- <a class="ProductGridItem bg-color-black color-white text-decoration-none hover--style-rounded-border relative p_625" href="{{ current_product.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
   <div class="bg-color-black h100">
     
     <div class="flex justify-between">
@@ -9,11 +9,47 @@
       <span class="ProductGridItem__price serif-xs uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
     </div>
     <span class="ProductGridItem__vendor sans-xs uppercase">{{current_product.vendor}}</span>
-    <div class="h1000 flex items-center justify-center">
+    <div class="debug flex items-center justify-center">
       <img class="ProductGridItem__image w100 h100 fit-contain" src="{{ product_media.src | img_url: 'x265' }}" alt="{{ product_media.alt | escape }}">
     </div>
 
-    <div class="ProductGridItem__details absolute b0 r0 w100 sans-xxs uppercase flex justify-between p_625">
+    <div class="ProductGridItem__details sans-xxs uppercase flex justify-between">
+      <span class="flex items-center">
+        <span class="dot mr_25"></span>
+        <span>{{ current_product.type }}</span>
+      </span>
+      <span class="radius-xs border-white p_25">Type Design</span>
+    </div>
+  </div>
+</a> -->
+
+
+
+
+<a class="ProductGridItem bg-color-black color-white text-decoration-none hover--style-rounded-border relative p_625" href="{{ current_product.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
+  <div class="ProductGridItem__inner-container bg-color-black h100">
+    
+    {% if current_product.metafields.accentuate.featured_product_text %}
+      <span class="flex flex-col uppercase">
+        <span class="color-yellow serif-md">
+          {{ current_product.metafields.accentuate.featured_product_text }}
+        </span>
+      <span class="ProductGridItem__title serif-md color-white">{{current_product.title}}</span>
+      <span class="ProductGridItem__vendor sans-xs">{{current_product.vendor}}</span>
+      </span>
+    {% else %}
+      <div class="flex justify-between">
+        <span class="ProductGridItem__title serif-xs uppercase">{{current_product.title}}</span>
+        <span class="ProductGridItem__price serif-xs uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
+      </div>
+      <span class="ProductGridItem__vendor sans-xs uppercase">{{current_product.vendor}}</span>
+    {% endif %}
+
+    <div class="ProductGridItem__image-container flex items-center justify-center absolute t0 r0 h100 w100">
+      <img class="ProductGridItem__image w100 h100 fit-contain" src="{{ product_media.src | img_url: 'x265' }}" alt="{{ product_media.alt | escape }}">
+    </div>
+
+    <div class="ProductGridItem__details absolute r0 b0 p_625 sans-xxs uppercase flex justify-between w100">
       <span class="flex items-center">
         <span class="dot mr_25"></span>
         <span>{{ current_product.type }}</span>
@@ -22,13 +58,3 @@
     </div>
   </div>
 </a>
-
-<!-- {% if current_product.metafields.accentuate.featured_product_text %}
-<span class="flex flex-col uppercase">
-  <span class="color-yellow serif-md">
-    {{ current_product.metafields.accentuate.featured_product_text }}
-  </span>
-<span class="ProductGridItem__title serif-md color-white">{{current_product.title}}</span>
-<span class="ProductGridItem__vendor sans-xs">{{current_product.vendor}}</span>
-</span>
-{% endif %} -->

--- a/theme/styles/_config.scss
+++ b/theme/styles/_config.scss
@@ -12,9 +12,10 @@ $breakpoints: (
   'xxs': 375px,
   'xs': 600px,
   'sm': 768px,
-  'md': 1024px,
-  'lg': 1440px,
-  'xl': 2600px,
+  'md': 900px,
+  'lg': 1024px,
+  'xl': 1440px,
+  'xxl': 2600px,
 );
 
 $additional-class-definitions: (

--- a/theme/styles/_config.scss
+++ b/theme/styles/_config.scss
@@ -5,7 +5,7 @@ $colors: (
   'transparent': rgba(255, 255, 255, 0),
 );
 
-$spacing-units: 0rem, 0.25rem, 0.5rem, 0.625rem, 0.75rem, 1rem, 1.25rem, 1.5rem, 1.75rem, 2rem,
+$spacing-units: 0rem, 0.125rem, 0.25rem, 0.5rem, 0.625rem, 0.75rem, 1rem, 1.25rem, 1.5rem, 1.75rem, 2rem,
   2.5rem, 2.75rem, 3rem, 3.5rem, 3.75rem, 4rem, 5rem, 6rem, 7rem, 8rem, 10rem;
 
 $breakpoints: (

--- a/theme/styles/_settings.scss
+++ b/theme/styles/_settings.scss
@@ -3,3 +3,4 @@
 @import 'settings/transitions';
 @import 'settings/z-index';
 @import 'settings/typography';
+@import 'settings/hover-state';

--- a/theme/styles/_snippets.scss
+++ b/theme/styles/_snippets.scss
@@ -1,2 +1,3 @@
 @import 'snippets/footer';
 @import 'snippets/home-header.scss';
+@import 'snippets/product-grid-item.scss';

--- a/theme/styles/buttons.scss
+++ b/theme/styles/buttons.scss
@@ -16,3 +16,11 @@
   color: color('inherit');
   text-decoration: none;
 }
+
+// .hover--style-rounded-border {
+//   border: 1px solid red;
+
+//   &:hover {
+//     border-radius: 0.5rem;
+//   }
+// }

--- a/theme/styles/buttons.scss
+++ b/theme/styles/buttons.scss
@@ -17,10 +17,10 @@
   text-decoration: none;
 }
 
-// .hover--style-rounded-border {
-//   border: 1px solid red;
+.hover--style-rounded-border {
+  @extend %transition;
 
-//   &:hover {
-//     border-radius: 0.5rem;
-//   }
-// }
+  &:hover {
+    border-radius: 0.5rem;
+  }
+}

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -22,35 +22,27 @@
   display: inline-block;
 }
 
-// .grid {
-//   padding-left: 0.125rem;
-//   padding-right: 0.125rem;
-//   display: grid;
-//   grid-gap: 0.125rem;
-//   grid-template-columns: repeat(auto-fill, minmax(375px, 1fr));
-
-//   @include media('md-up') {
-//     grid-template-columns: repeat(auto-fill, minmax(481px, 1fr));
-//   }
-// }
-
+//* Product Grid */
 .grid {
   display: grid;
-  padding-left: 0.125rem;
-  padding-right: 0.125rem;
-  gap: 0.125rem;
-  grid-template-columns: repeat(auto-fill, minmax(375px, 1fr));
+    padding-left: 0.125rem;
+    padding-right: 0.125rem;
+    gap: 0.125rem;
+    grid-template-columns: 1fr;
 
-  @include media('md-up') {
-    grid-template-columns: repeat(3, 1fr);
+    @include media('md-up') {
+      grid-template-columns: repeat(3, 1fr);
+    }
 
-    > :first-child {
-      grid-column: 1/3;
-      grid-row: 1/3;
+  &--style-featured-product {
+    @include media('lg-up') {
+      > :first-child {
+        grid-column: 1/3;
+        grid-row: 1/3;
 
-      .ProductGridItem__image {
-        min-height: 31.25rem!important;
-        max-height: unset;
+        img {
+          min-height: 31.25rem!important;
+        }
       }
     }
   }

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -21,3 +21,40 @@
   border-radius: 50%;
   display: inline-block;
 }
+
+// .grid {
+//   padding-left: 0.125rem;
+//   padding-right: 0.125rem;
+//   display: grid;
+//   grid-gap: 0.125rem;
+//   grid-template-columns: repeat(auto-fill, minmax(375px, 1fr));
+
+//   @include media('md-up') {
+//     grid-template-columns: repeat(auto-fill, minmax(481px, 1fr));
+//   }
+// }
+
+.grid {
+  display: grid;
+  padding-left: 0.125rem;
+  padding-right: 0.125rem;
+  grid-gap: 0.125rem;
+  grid-template-columns: repeat(auto-fill, minmax(375px, 1fr));
+
+  @include media('md-up') {
+    grid-template-columns: repeat(3, 1fr);
+
+    > :first-child {
+      grid-column: 1/3;
+      grid-row: 1/3;
+
+      .ProductGridItem__image {
+        height: 31.25rem;
+        padding-top: 5rem;
+        padding-bottom: 5rem;
+      }
+    }
+  }
+
+  
+}

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -38,7 +38,7 @@
   display: grid;
   padding-left: 0.125rem;
   padding-right: 0.125rem;
-  grid-gap: 0.125rem;
+  gap: 0.125rem;
   grid-template-columns: repeat(auto-fill, minmax(375px, 1fr));
 
   @include media('md-up') {
@@ -49,12 +49,9 @@
       grid-row: 1/3;
 
       .ProductGridItem__image {
-        height: 31.25rem;
-        padding-top: 5rem;
-        padding-bottom: 5rem;
+        min-height: 31.25rem!important;
+        max-height: unset;
       }
     }
   }
-
-  
 }

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -7,3 +7,17 @@
     padding-right: $site-padding-x-desktop;
   }
 }
+
+.button--style-primary {
+  @extend %transition-shorter;
+  border-radius: 0.75rem;
+  border: 1px solid color('black');
+  text-transform: uppercase;
+  color: color('black');
+  text-decoration: none;
+
+  &:hover {
+    background-color: color('black');
+    color: color('white');
+  }
+}

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -1,3 +1,4 @@
+//* Global Padding */
 .site-padding-x {
   padding-left: $site-padding-x-mobile;
   padding-right: $site-padding-x-mobile;
@@ -8,16 +9,15 @@
   }
 }
 
-.button--style-primary {
-  @extend %transition-shorter;
-  border-radius: 0.75rem;
-  border: 1px solid color('black');
-  text-transform: uppercase;
-  color: color('black');
-  text-decoration: none;
+//* Borders */
+.border-white {
+  border: 1px solid color('white');
+}
 
-  &:hover {
-    background-color: color('black');
-    color: color('white');
-  }
+.dot {
+  height: 0.8125rem;
+  width: 0.8125rem;
+  background-color: color('white');
+  border-radius: 50%;
+  display: inline-block;
 }

--- a/theme/styles/settings/_hover-state.scss
+++ b/theme/styles/settings/_hover-state.scss
@@ -1,0 +1,27 @@
+@each $name, $color in $colors {
+  @if type-of($color) == color {
+    .hover-darken-#{$name} {
+      &:hover {
+        color: darken($color, 20%);
+      }
+    }
+
+    .hover-lighten-#{$name} {
+      &:hover {
+        color: lighten($color, 20%);
+      }
+    }
+
+    .hover-bg-color-#{$name} {
+      &:hover {
+        background-color: $color;
+      }
+    }
+
+    .hover-color-#{$name} {
+      &:hover {
+        color: $color;
+      }
+    }
+  }
+}

--- a/theme/styles/settings/_hover-state.scss
+++ b/theme/styles/settings/_hover-state.scss
@@ -8,7 +8,7 @@
 
     .hover-lighten-#{$name} {
       &:hover {
-        color: lighten($color, 20%);
+        color: lighten($color, 25%);
       }
     }
 

--- a/theme/styles/settings/_radius.scss
+++ b/theme/styles/settings/_radius.scss
@@ -1,6 +1,7 @@
 $border-radius: (
   'none': 0rem,
   'xs': 0.375rem,
+  'md': 0.75rem
 );
 
 @function radius($radius) {

--- a/theme/styles/settings/_radius.scss
+++ b/theme/styles/settings/_radius.scss
@@ -1,5 +1,6 @@
 $border-radius: (
   'none': 0rem,
+  'xs': 0.375rem,
 );
 
 @function radius($radius) {

--- a/theme/styles/settings/_typography.scss
+++ b/theme/styles/settings/_typography.scss
@@ -29,8 +29,14 @@
 }
 
 .serif-md {
-  font-size: 2.5rem;
-  line-height: 2.625rem;
+  font-size: 1.125rem;
+  line-height: 1.35rem;
+  letter-spacing: 0.0275rem;
+
+  @include media('md-up') {
+    font-size: 2.5rem;
+    line-height: 2.625rem;
+  }
 }
 
 .serif-xs {

--- a/theme/styles/settings/_typography.scss
+++ b/theme/styles/settings/_typography.scss
@@ -22,7 +22,7 @@
   font-size: 2.5rem;
   line-height: 2.625rem;
 
-  @include media('md-up') {
+  @include media('lg-up') {
     font-size: 4.6875rem;
     line-height: 4.6875rem;
   }
@@ -33,7 +33,7 @@
   line-height: 1.35rem;
   letter-spacing: 0.0275rem;
 
-  @include media('md-up') {
+  @include media('lg-up') {
     font-size: 2.5rem;
     line-height: 2.625rem;
   }
@@ -60,7 +60,7 @@
   font-size: 3.125rem;
   line-height: 2.8125rem;
 
-  @include media('md-up') {
+  @include media('lg-up') {
     font-size: 4.0625rem;
     line-height: 3.65625rem;
   }
@@ -70,7 +70,7 @@
   font-size: 1.875rem;
   line-height: 1.6875rem;
 
-  @include media('md-up') {
+  @include media('lg-up') {
     font-size: 3.125rem;
     line-height: 2.8125rem;
   }

--- a/theme/styles/snippets/product-grid-item.scss
+++ b/theme/styles/snippets/product-grid-item.scss
@@ -22,22 +22,18 @@
 
     @include media('xs-up') {
       max-height: 22rem;
-      padding: 1rem 0;
     }
 
     @include media('md-up') {
       max-height: 11rem;
-      padding: 1rem 0;
     }
 
     @include media('lg-up') {
       max-height: 14rem;
-      padding: 1rem 0;
     }
 
     @include media('xl-up') {
       max-height: 17rem;
-      padding: 1rem 0;
     }
   }
 }

--- a/theme/styles/snippets/product-grid-item.scss
+++ b/theme/styles/snippets/product-grid-item.scss
@@ -1,3 +1,22 @@
 .ProductGridItem {
+  // &::before {
+  //   content: "";
+  //   display: block;
+  //   height: 0;
+  //   width: 0;
+  //   padding-bottom: calc(480/499 * 100%);
+  // }
 
+  &__image {
+    width: 50%;
+    height: 16.5625rem;
+    padding-top: 2.5rem;
+    padding-bottom: 2.5rem;
+
+    @include media('md-up') {
+      height: 18rem;
+      padding-top: 2rem;
+      padding-bottom: 2rem;
+    }
+  }
 }

--- a/theme/styles/snippets/product-grid-item.scss
+++ b/theme/styles/snippets/product-grid-item.scss
@@ -1,22 +1,26 @@
 .ProductGridItem {
-  // &::before {
-  //   content: "";
-  //   display: block;
-  //   height: 0;
-  //   width: 0;
-  //   padding-bottom: calc(480/499 * 100%);
-  // }
+  display: grid;
+
+  &::before {
+    content: "";
+    display: block;
+    height: 0;
+    width: 0;
+    padding-bottom: calc(480/499 * 100%);
+    grid-area: 1 / 1 / 2 / 2;
+  }
+
+  &__inner-container {
+    grid-area: 1 / 1 / 2 / 2;
+    width: 100%
+  }
 
   &__image {
-    width: 50%;
-    height: 16.5625rem;
-    padding-top: 2.5rem;
-    padding-bottom: 2.5rem;
+    width: 60%;
+    max-height: 14rem;
 
-    @include media('md-up') {
-      height: 18rem;
-      padding-top: 2rem;
-      padding-bottom: 2rem;
+    @include media('lg-up') {
+      max-height: 16.75rem;
     }
   }
 }

--- a/theme/styles/snippets/product-grid-item.scss
+++ b/theme/styles/snippets/product-grid-item.scss
@@ -1,6 +1,7 @@
 .ProductGridItem {
   display: grid;
 
+  //Aspect ratio 
   &::before {
     content: "";
     display: block;
@@ -17,10 +18,26 @@
 
   &__image {
     width: 60%;
-    max-height: 14rem;
+    max-height: 13rem;
+
+    @include media('xs-up') {
+      max-height: 22rem;
+      padding: 1rem 0;
+    }
+
+    @include media('md-up') {
+      max-height: 11rem;
+      padding: 1rem 0;
+    }
 
     @include media('lg-up') {
-      max-height: 16.75rem;
+      max-height: 14rem;
+      padding: 1rem 0;
+    }
+
+    @include media('xl-up') {
+      max-height: 17rem;
+      padding: 1rem 0;
     }
   }
 }

--- a/theme/styles/snippets/product-grid-item.scss
+++ b/theme/styles/snippets/product-grid-item.scss
@@ -1,0 +1,3 @@
+.ProductGridItem {
+
+}

--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -1,13 +1,5 @@
-{% paginate collection.products by 2 %}
-  <h1>{{ collection.title }}</h1>
+<div class="Collection">
   {% for product in collection.products %}
-    {% for product in collection.products %}
-      {% render 'product-grid-item', current_product: product %}
-    {% endfor %}
-  {% else %}
-    <p>no matches</p>
+    {% render 'product-grid-item', current_product: product %}
   {% endfor %}
-  {% if paginate.pages > 1 %}
-    {{ paginate | default_pagination }}
-  {% endif %}
-{% endpaginate %}
+</div>

--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -1,14 +1,9 @@
 {% paginate collection.products by 2 %}
   <h1>{{ collection.title }}</h1>
   {% for product in collection.products %}
-    <div>
-      <a href="{{ product.url | within: collection }}">{{ product.title }}</a>
-      {{ product.price | money }}
-      {% unless product.available %}<br><strong>sold out</strong>{% endunless %}
-      <a href="{{ product.url | within: collection }}">
-        <img src="{{ product.featured_image.src | img_url: 'large' }}" alt="{{ product.featured_image.alt | escape }}">
-      </a>
-    </div>
+    {% for product in collection.products %}
+      {% render 'product-grid-item', current_product: product %}
+    {% endfor %}
   {% else %}
     <p>no matches</p>
   {% endfor %}

--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -1,4 +1,4 @@
-<div class="Collection">
+<div class="Collection grid">
   {% for product in collection.products %}
     {% render 'product-grid-item', current_product: product %}
   {% endfor %}

--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -1,5 +1,18 @@
-<div class="Collection grid">
+{% paginate collection.products by 2 %}
+  <h1>{{ collection.title }}</h1>
   {% for product in collection.products %}
-    {% render 'product-grid-item', current_product: product %}
+    <div>
+      <a href="{{ product.url | within: collection }}">{{ product.title }}</a>
+      {{ product.price | money }}
+      {% unless product.available %}<br><strong>sold out</strong>{% endunless %}
+      <a href="{{ product.url | within: collection }}">
+        <img src="{{ product.featured_image.src | img_url: 'large' }}" alt="{{ product.featured_image.alt | escape }}">
+      </a>
+    </div>
+  {% else %}
+    <p>no matches</p>
   {% endfor %}
-</div>
+  {% if paginate.pages > 1 %}
+    {{ paginate | default_pagination }}
+  {% endif %}
+{% endpaginate %}

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -1,10 +1,4 @@
 {% render 'home-header' %}
-{% for product in collections.frontpage.products %}
-  <div>
-    <a href="{{ product.url | within: collection }}">{{ product.title }}</a>
-    {{ product.price | money }}
-    <a href="{{ product.url | within: collection }}">
-      <img src="{{ product.featured_image.src | img_url: 'large' }}" alt="{{ product.featured_image.alt | escape }}">
-    </a>
-  </div>
+  {% for product in collections.frontpage.products %}
+    {% render 'product-grid-item', current_product: product %}  
 {% endfor %}

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -1,5 +1,9 @@
 {% render 'home-header' %}
-<div class="">
+
+{% comment %} if collections metafield featured product is true, show the style featured product. else show the default. {% endcomment %}
+
+
+<div class="grid">
   {% for product in collections.frontpage.products %}
     {% render 'product-grid-item', current_product: product %}  
 {% endfor %}

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -1,12 +1,13 @@
 {% render 'home-header' %}
 
-{% comment %} if collections metafield featured product is true, show the style featured product. else show the default. {% endcomment %}
+{% assign show_featured_product = collections.frontpage.metafields.accentuate.show_featured_product %}
 
-
-<div class="grid">
+{% if show_featured_product %}
+  <div class="grid grid--style-featured-product">
+    {% else %}
+    <div class="grid">
+{% endif %}
   {% for product in collections.frontpage.products %}
-    {% render 'product-grid-item', current_product: product %}  
+    {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}  
   {% endfor %}
 </div>
-
-<!-- collection.metafields.accentuate.show_featured_product -->

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -6,6 +6,7 @@
 <div class="grid">
   {% for product in collections.frontpage.products %}
     {% render 'product-grid-item', current_product: product %}  
-{% endfor %}
-
+  {% endfor %}
 </div>
+
+<!-- collection.metafields.accentuate.show_featured_product -->

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -1,4 +1,7 @@
 {% render 'home-header' %}
+<div class="">
   {% for product in collections.frontpage.products %}
     {% render 'product-grid-item', current_product: product %}  
 {% endfor %}
+
+</div>

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -2,11 +2,7 @@
 
 {% assign show_featured_product = collections.frontpage.metafields.accentuate.show_featured_product %}
 
-{% if show_featured_product %}
-  <div class="grid grid--style-featured-product">
-    {% else %}
-    <div class="grid">
-{% endif %}
+<div class="grid {% if show_featured_product %} grid--style-featured-product {% endif %}">
   {% for product in collections.frontpage.products %}
     {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}  
   {% endfor %}


### PR DESCRIPTION
### Description
- Adds `Product Grid Item` and `Product Grid`
- In Shopify, the user can manually choose the order of the products in the `Featured Collection` (collection on the home page)
- Since they can choose the order, the first product will be the `Featured Product`. 
- In the Accentuate custom fields for `Collections`, there is a checkbox for `show_featured_product` layout. If true, the `first child` (first product) is given the classes to make it a larger, featured product.
- Every product can have an Accentuate custom field for `Featured Product Text` ("This week") 

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] New feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
Closes #39 
Closes #13 

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://jczdog9k04ldnnei-52674822324.shopifypreview.com
pw: nunu

- If you uncheck the box for "Show Featured Product" then you can see the 3 col grid without a `Featured Product`
- Go to the Collection > More Actions > Custom Fields

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->
![image](https://user-images.githubusercontent.com/43737723/105227000-58b3df00-5b26-11eb-9839-5cbf2fdfea6d.png)
![image](https://user-images.githubusercontent.com/43737723/105227018-60738380-5b26-11eb-8f25-801a84ec4cdd.png)

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
- Added a TO-DO: The Knowledge Area (bottom right corner, "Type Design") is a placeholder for now because I'm not sure how Knowledge Areas will work yet, and if this will be an Accentuate custom field or a Shopify tag. 