### PR TITLE
Add Homepage News Feed

### DIFF
--- a/theme/locales/en.default.json
+++ b/theme/locales/en.default.json
@@ -42,6 +42,12 @@
       "product_btn": {
         "aria_label": "Navigate to the product page."
       }
+    },
+    "news_feed": {
+      "see_more_link": {
+        "aria_label": "See more News.",
+        "text": "See more"
+      }
     }
   }
 }

--- a/theme/snippets/news-feed-item.liquid
+++ b/theme/snippets/news-feed-item.liquid
@@ -1,5 +1,5 @@
-<div class="NewsFeedItem overflow-hidden overflow-x-scroll flex items-center border-bottom-black py1_25 md:p_75">
-  <div class="flex items-center justify-center col-1 md:pr2_5">
+<div class="NewsFeedItem overflow-hidden overflow-x-scroll flex items-center border-bottom-black py1_25 md:py_75">
+  <div class="flex col-1 md:pl_75">
     <img class="NewsFeedItem__image fit-contain w100 h100" src="{{ image_src }}" alt="{{ image_alt }}"/>
   </div>
 

--- a/theme/snippets/news-feed-item.liquid
+++ b/theme/snippets/news-feed-item.liquid
@@ -1,10 +1,10 @@
 <div class="NewsFeedItem overflow-hidden overflow-x-scroll flex items-center border-bottom-black py1_25 md:py_75 xs:pr0">
-  <div class="flex col-1 md:pl_75">
+  <div class="flex col-1 md:mx_75">
     <img class="NewsFeedItem__image fit-contain w100 h100" src="{{ image_src }}" alt="{{ image_alt }}"/>
   </div>
 
-  <div class="NewsFeedItem__text-row flex justify-between col-11">
-    <span class="px1">{{ text }}</span>
-    <a class="sans-xs hover-lighten-black" href="{{ button_link }}" aria-label="Navigate to {{ button_label }}">{{ button_label }}</a>
+  <div class="flex items-center justify-between col-11">
+    <span class="NewsFeedItem__body serif px1">{{ body.html }}</span>
+    <span class="NewsFeedItem__third-column sans-xs sans-serif md:pl2">{{ third_column.html }}</span>
   </div>
 </div>

--- a/theme/snippets/news-feed-item.liquid
+++ b/theme/snippets/news-feed-item.liquid
@@ -1,10 +1,10 @@
-<div class="NewsFeed__row flex items-center border-bottom-black py1_25 md:p_75">
+<div class="NewsFeedItem overflow-hidden overflow-x-scroll flex items-center border-bottom-black py1_25 md:p_75">
   <div class="flex items-center justify-center col-1 md:pr2_5">
-    <img class="NewsFeed__image fit-contain w100 h100" src="{{ image_src }}" alt="{{ image_alt }}"/>
+    <img class="NewsFeedItem__image fit-contain w100 h100" src="{{ image_src }}" alt="{{ image_alt }}"/>
   </div>
 
-  <div class="NewsFeed__text-row flex justify-between col-11">
+  <div class="NewsFeedItem__text-row flex justify-between col-11">
     <span class="pr1">{{ text }}</span>
-    <a class="sans-xs" href="{{ button_link }}" aria-label="Navigate to {{ button_label }}">{{ button_label }}</a>
+    <a class="sans-xs hover-lighten-black" href="{{ button_link }}" aria-label="Navigate to {{ button_label }}">{{ button_label }}</a>
   </div>
 </div>

--- a/theme/snippets/news-feed-item.liquid
+++ b/theme/snippets/news-feed-item.liquid
@@ -1,0 +1,10 @@
+<div class="NewsFeed__row flex items-center border-bottom-black py1_25 md:p_75">
+  <div class="flex items-center justify-center col-1 md:pr2_5">
+    <img class="NewsFeed__image fit-contain w100 h100" src="{{ image_src }}" alt="{{ image_alt }}"/>
+  </div>
+
+  <div class="NewsFeed__text-row flex justify-between col-11">
+    <span class="pr1">{{ text }}</span>
+    <a class="sans-xs" href="{{ button_link }}" aria-label="Navigate to {{ button_label }}">{{ button_label }}</a>
+  </div>
+</div>

--- a/theme/snippets/news-feed-item.liquid
+++ b/theme/snippets/news-feed-item.liquid
@@ -1,10 +1,10 @@
-<div class="NewsFeedItem overflow-hidden overflow-x-scroll flex items-center border-bottom-black py1_25 md:py_75">
+<div class="NewsFeedItem overflow-hidden overflow-x-scroll flex items-center border-bottom-black py1_25 md:py_75 xs:pr0">
   <div class="flex col-1 md:pl_75">
     <img class="NewsFeedItem__image fit-contain w100 h100" src="{{ image_src }}" alt="{{ image_alt }}"/>
   </div>
 
   <div class="NewsFeedItem__text-row flex justify-between col-11">
-    <span class="pr1">{{ text }}</span>
+    <span class="px1">{{ text }}</span>
     <a class="sans-xs hover-lighten-black" href="{{ button_link }}" aria-label="Navigate to {{ button_label }}">{{ button_label }}</a>
   </div>
 </div>

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,5 +1,5 @@
   <div class="NewsFeed site-margin-x flex flex-col">
-    <div class="NewsFeed__inner-container flex flex-col border-top-black border-bottom-black my3">
+    <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black my3">
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Elliot Keeler is teaching Intro to coding this spring!', button_label: 'Register', button_link: '/register' %}
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'We just got a bunch of vintage graphic design family heirlooms.', button_label: 'Browse', button_link: '/register' %}
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Jake is studying the ergonomics of sitting.', button_label: 'Learn', button_link: '/register' %}

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,6 +1,6 @@
   <div class="NewsFeed site-margin-x flex flex-col">
     <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black">
-    {% for value in shop.metafields.accentuate.news_feed_item_text %} 
+    {% for value in shop.metafields.accentuate.news_feed_item_text limit:4 %} 
       {% assign multi_thumbnails = shop.metafields.accentuate.news_feed_item_thumbnail[forloop.index0] %}
       {% for thumbnail in multi_thumbnails %} 
         {% assign current_thumbnail = thumbnail %}

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,18 +1,12 @@
   <div class="NewsFeed site-margin-x flex flex-col">
     <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black">
 
-      {% for value in shop.metafields.accentuate.news_feed_item_text %} 
-      <div>
-        {{ value }}       {{ shop.metafields.accentuate.news_feed_item_link_label[forloop.index0] }}
-        {{ shop.metafields.accentuate.news_feed_item_link[forloop.index0] }}
-      </div>
+    {% for value in shop.metafields.accentuate.news_feed_item_thumbnail %} 
+ 
+      {{ value }}
+      {% render 'news-feed-item', image_src: value_image_src image_alt: value.alt text: shop.metafields.accentuate.news_feed_item_text[forloop.index0], button_label: shop.metafields.accentuate.news_feed_item_link_label[forloop.index0], button_link: shop.metafields.accentuate.news_feed_item_link[forloop.index0] %}
     {% endfor %} 
 
-
-      <!-- {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Elliot Keeler is teaching Intro to coding this spring!', button_label: 'Register', button_link: '/register' %}
-      {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'We just got a bunch of vintage graphic design family heirlooms.', button_label: 'Browse', button_link: '/register' %}
-      {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Jake is studying the ergonomics of sitting.', button_label: 'Learn', button_link: '/register' %}
-      {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Learn about birdwatching with Sara Camnasio this Wednesday night.', button_label: 'Register', button_link: '/register' %} -->
     </div>
   
     <a class="uppercase serif-xl pt2 md:pt5 pb3 hover-lighten-black" href="/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,4 +1,4 @@
-  <div class="NewsFeed site-margin-x flex flex-col">
+  <div class="NewsFeed flex flex-col">
     <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black">
     {% for value in shop.metafields.accentuate.news_feed_item_text limit:4 %} 
       {% assign multi_thumbnails = shop.metafields.accentuate.news_feed_item_thumbnail[forloop.index0] %}

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,10 +1,10 @@
   <div class="NewsFeed site-margin-x flex flex-col">
-    <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black my3">
+    <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black">
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Elliot Keeler is teaching Intro to coding this spring!', button_label: 'Register', button_link: '/register' %}
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'We just got a bunch of vintage graphic design family heirlooms.', button_label: 'Browse', button_link: '/register' %}
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Jake is studying the ergonomics of sitting.', button_label: 'Learn', button_link: '/register' %}
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Learn about birdwatching with Sara Camnasio this Wednesday night.', button_label: 'Register', button_link: '/register' %}
     </div>
   
-    <a class="uppercase serif-xl pb3 hover-lighten-black" href="/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>
+    <a class="uppercase serif-xl pt2 md:pt5 pb3 hover-lighten-black" href="/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>
   </div>

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,12 +1,12 @@
   <div class="NewsFeed site-margin-x flex flex-col">
     <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black">
-
-    {% for value in shop.metafields.accentuate.news_feed_item_thumbnail %} 
- 
-      {{ value }}
-      {% render 'news-feed-item', image_src: value_image_src image_alt: value.alt text: shop.metafields.accentuate.news_feed_item_text[forloop.index0], button_label: shop.metafields.accentuate.news_feed_item_link_label[forloop.index0], button_link: shop.metafields.accentuate.news_feed_item_link[forloop.index0] %}
+    {% for value in shop.metafields.accentuate.news_feed_item_text %} 
+      {% assign multi_thumbnails = shop.metafields.accentuate.news_feed_item_thumbnail[forloop.index0] %}
+      {% for thumbnail in multi_thumbnails %} 
+        {% assign current_thumbnail = thumbnail %}
+      {% endfor %}
+      {% render 'news-feed-item', image_src: current_thumbnail.src image_alt: current_thumbnail.alt text: value, button_label: shop.metafields.accentuate.news_feed_item_link_label[forloop.index0], button_link: shop.metafields.accentuate.news_feed_item_link[forloop.index0] %}
     {% endfor %} 
-
     </div>
   
     <a class="uppercase serif-xl pt2 md:pt5 pb3 hover-lighten-black" href="/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,9 +1,18 @@
   <div class="NewsFeed site-margin-x flex flex-col">
     <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black">
-      {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Elliot Keeler is teaching Intro to coding this spring!', button_label: 'Register', button_link: '/register' %}
+
+      {% for value in shop.metafields.accentuate.news_feed_item_text %} 
+      <div>
+        {{ value }}       {{ shop.metafields.accentuate.news_feed_item_link_label[forloop.index0] }}
+        {{ shop.metafields.accentuate.news_feed_item_link[forloop.index0] }}
+      </div>
+    {% endfor %} 
+
+
+      <!-- {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Elliot Keeler is teaching Intro to coding this spring!', button_label: 'Register', button_link: '/register' %}
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'We just got a bunch of vintage graphic design family heirlooms.', button_label: 'Browse', button_link: '/register' %}
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Jake is studying the ergonomics of sitting.', button_label: 'Learn', button_link: '/register' %}
-      {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Learn about birdwatching with Sara Camnasio this Wednesday night.', button_label: 'Register', button_link: '/register' %}
+      {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Learn about birdwatching with Sara Camnasio this Wednesday night.', button_label: 'Register', button_link: '/register' %} -->
     </div>
   
     <a class="uppercase serif-xl pt2 md:pt5 pb3 hover-lighten-black" href="/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,0 +1,16 @@
+  <div class="NewsFeed site-margin-x flex flex-col">
+
+    <div class="NewsFeed__inner-container flex flex-col border-top-black border-bottom-black my3">
+
+      {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Elliot Keeler is teaching Intro to coding this spring!', button_label: 'Register', button_link: '/register' %}
+
+      {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'We just got a bunch of vintage graphic design family heirlooms.', button_label: 'Browse', button_link: '/register' %}
+
+      {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Jake is studying the ergonomics of sitting.', button_label: 'Learn', button_link: '/register' %}
+
+      {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Learn about birdwatching with Sara Camnasio this Wednesday night.', button_label: 'Register', button_link: '/register' %}
+  
+    </div>
+  
+    <a class="uppercase serif-xl pb3" href="/news" aria-label="">See more</a>
+  </div>

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,13 +1,13 @@
-  <div class="NewsFeed flex flex-col">
-    <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black">
-    {% for value in shop.metafields.accentuate.news_feed_item_text limit:4 %} 
-      {% assign multi_thumbnails = shop.metafields.accentuate.news_feed_item_thumbnail[forloop.index0] %}
-      {% for thumbnail in multi_thumbnails %} 
-        {% assign current_thumbnail = thumbnail %}
-      {% endfor %}
-      {% render 'news-feed-item', image_src: current_thumbnail.src image_alt: current_thumbnail.alt text: value, button_label: shop.metafields.accentuate.news_feed_item_link_label[forloop.index0], button_link: shop.metafields.accentuate.news_feed_item_link[forloop.index0] %}
-    {% endfor %} 
-    </div>
-  
-    <a class="uppercase serif-xl pt2 md:pt5 pb3 hover-lighten-black" href="/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>
+<div class="NewsFeed flex flex-col">
+  <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black">
+  {% for value in shop.metafields.accentuate.news_feed_item_body limit:4 %} 
+    {% assign multi_thumbnails = shop.metafields.accentuate.news_feed_item_thumbnail[forloop.index0] %}
+    {% for thumbnail in multi_thumbnails %} 
+      {% assign current_thumbnail = thumbnail %}
+    {% endfor %}
+    {% render 'news-feed-item', image_src: current_thumbnail.src image_alt: current_thumbnail.alt body: value, third_column: shop.metafields.accentuate.news_feed_item_third_column[forloop.index0] %}
+  {% endfor %} 
   </div>
+
+  <a class="uppercase serif-xl pt2 md:pt5 pb3 hover-lighten-black" href="/pages/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>
+</div>

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,16 +1,10 @@
   <div class="NewsFeed site-margin-x flex flex-col">
-
     <div class="NewsFeed__inner-container flex flex-col border-top-black border-bottom-black my3">
-
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Elliot Keeler is teaching Intro to coding this spring!', button_label: 'Register', button_link: '/register' %}
-
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'We just got a bunch of vintage graphic design family heirlooms.', button_label: 'Browse', button_link: '/register' %}
-
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Jake is studying the ergonomics of sitting.', button_label: 'Learn', button_link: '/register' %}
-
       {% render 'news-feed-item', image_src: "https://dijf55il5e0d1.cloudfront.net/images/rr/8/5/7/85798_1000.jpg" image_alt: "Image of Elliot Keeler" text: 'Learn about birdwatching with Sara Camnasio this Wednesday night.', button_label: 'Register', button_link: '/register' %}
-  
     </div>
   
-    <a class="uppercase serif-xl pb3" href="/news" aria-label="">See more</a>
+    <a class="uppercase serif-xl pb3 hover-lighten-black" href="/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>
   </div>

--- a/theme/styles/_snippets.scss
+++ b/theme/styles/_snippets.scss
@@ -1,3 +1,4 @@
 @import 'snippets/footer';
 @import 'snippets/home-header.scss';
 @import 'snippets/product-grid-item.scss';
+@import 'snippets/news-feed';

--- a/theme/styles/_snippets.scss
+++ b/theme/styles/_snippets.scss
@@ -2,3 +2,4 @@
 @import 'snippets/home-header.scss';
 @import 'snippets/product-grid-item.scss';
 @import 'snippets/news-feed';
+@import 'snippets/news-feed-item';

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -9,9 +9,27 @@
   }
 }
 
+.site-margin-x {
+  margin-left: $site-padding-x-mobile;
+  margin-right: $site-padding-x-mobile;
+
+  @include media('md-up') {
+    margin-left: $site-padding-x-desktop;
+    margin-right: $site-padding-x-desktop;
+  }
+}
+
 //* Borders */
 .border-white {
   border: 1px solid color('white');
+}
+
+.border-top-black {
+  border-top: 1px solid color('black');
+}
+
+.border-bottom-black {
+  border-bottom: 1px solid color('black');
 }
 
 .dot {

--- a/theme/styles/settings/_typography.scss
+++ b/theme/styles/settings/_typography.scss
@@ -69,7 +69,8 @@
   line-height: 2.1rem;
 }
 
-.serif-xs {
+.serif-xs,
+%serif-xs {
   font-size: 1.125rem;
   line-height: 1.35rem;
   letter-spacing: 0.0275rem;

--- a/theme/styles/settings/_typography.scss
+++ b/theme/styles/settings/_typography.scss
@@ -22,7 +22,7 @@
   font-size: 4.6875rem;
   line-height: 4.6875rem;
 
-  @include media('md-up') {
+  @include media('lg-up') {
     font-size: 9.375rem;
     line-height: 9.375rem;
   }
@@ -41,8 +41,9 @@
 
 .serif-lg,
 %serif-lg {
-  font-size: 2.5rem;
-  line-height: 2.625rem;
+  font-size: 1.125rem;
+  line-height: 1.35rem;
+  letter-spacing: 0.0275rem;
 
   @include media('lg-up') {
     font-size: 3.125rem;
@@ -108,8 +109,14 @@
 
 .sans-sm,
 %sans-sm {
-  font-size: 1.875rem;
-  line-height: 1.6875rem;
+  font-size: 1rem;
+  line-height: 1.171875rem;
+  letter-spacing: 0.0275rem;
+
+  @include media('lg-up') {
+    font-size: 1.875rem;
+    line-height: 1.6875rem;
+  }
 }
 
 .sans-xs,

--- a/theme/styles/snippets/home-header.scss
+++ b/theme/styles/snippets/home-header.scss
@@ -6,7 +6,7 @@
     font-size: 2.5rem;
     line-height: 2.625rem;
 
-    @include media('md-up') {
+    @include media('lg-up') {
       font-size: 4.0625rem;
       line-height: 3.65625rem;
     }

--- a/theme/styles/snippets/news-feed-item.scss
+++ b/theme/styles/snippets/news-feed-item.scss
@@ -1,20 +1,10 @@
 .NewsFeedItem {
-  min-width: 55rem;
-  font-family: $itc-garamond;
-  font-size: 1.125rem;
-  line-height: 1.35rem;
-  letter-spacing: 0.0275rem;
+  min-width: 40rem;
   padding-right: $site-padding-x-mobile;
 
-  @include media('md-up') {
-    font-size: 3.125rem;
-    line-height: 2.8125rem;
-  }
-
   a {
-    @include media('md-up') {
-      font-size: 1.875rem;
-      line-height: 1.6875rem;
+    &:hover {
+      color: lighten(black, 25%);
     }
   }
 
@@ -25,6 +15,24 @@
     @include media('md-up') {
       width: 4rem;
       height: 4rem;
+    }
+  }
+
+  &__body {
+    font-size: 1.125rem;
+    line-height: 1.35rem;
+    letter-spacing: 0.0275rem;
+
+    @include media('md-up') {
+      font-size: 3.125rem;
+      line-height: 2.8125rem;
+      min-width: 55rem;
+    }
+  }
+  &__third-column p, &__third-column p a {
+    @include media('md-up') {
+      font-size: 1.875rem;
+      line-height: 1.6875rem;
     }
   }
 }

--- a/theme/styles/snippets/news-feed-item.scss
+++ b/theme/styles/snippets/news-feed-item.scss
@@ -19,9 +19,7 @@
   }
 
   &__body {
-    font-size: 1.125rem;
-    line-height: 1.35rem;
-    letter-spacing: 0.0275rem;
+    @extend %serif-xs;
 
     @include media('md-up') {
       font-size: 3.125rem;
@@ -29,6 +27,7 @@
       min-width: 55rem;
     }
   }
+
   &__third-column p, &__third-column p a {
     @include media('md-up') {
       font-size: 1.875rem;

--- a/theme/styles/snippets/news-feed-item.scss
+++ b/theme/styles/snippets/news-feed-item.scss
@@ -4,6 +4,7 @@
   font-size: 1.125rem;
   line-height: 1.35rem;
   letter-spacing: 0.0275rem;
+  padding-right: $site-padding-x-mobile;
 
   @include media('md-up') {
     font-size: 3.125rem;

--- a/theme/styles/snippets/news-feed-item.scss
+++ b/theme/styles/snippets/news-feed-item.scss
@@ -1,0 +1,29 @@
+.NewsFeedItem {
+  min-width: 55rem;
+  font-family: $itc-garamond;
+  font-size: 1.125rem;
+  line-height: 1.35rem;
+  letter-spacing: 0.0275rem;
+
+  @include media('md-up') {
+    font-size: 3.125rem;
+    line-height: 2.8125rem;
+  }
+
+  a {
+    @include media('md-up') {
+      font-size: 1.875rem;
+      line-height: 1.6875rem;
+    }
+  }
+
+  &__image {
+    width: 3.4375rem;
+    height: 3.4375rem;
+
+    @include media('md-up') {
+      width: 4rem;
+      height: 4rem;
+    }
+  }
+}

--- a/theme/styles/snippets/news-feed.scss
+++ b/theme/styles/snippets/news-feed.scss
@@ -1,0 +1,42 @@
+.NewsFeed {
+
+  &__inner-container {
+    overflow-x: scroll;
+
+    > :last-child {
+      border-bottom: 0;
+    }  
+  }
+  
+  &__image {
+    width: 3.4375rem;
+    height: 3.4375rem;
+
+    @include media('md-up') {
+      width: 4rem;
+      height: 4rem;
+    }
+  }
+
+  &__row {
+    min-width: 55rem;
+    overflow: hidden;
+    overflow-x: scroll;
+    font-family: $itc-garamond;
+    font-size: 1.125rem;
+    line-height: 1.35rem;
+    letter-spacing: 0.0275rem;
+  
+    @include media('md-up') {
+      font-size: 3.125rem;
+      line-height: 2.8125rem;
+    }
+
+    a {
+      @include media('md-up') {
+        font-size: 1.875rem;
+        line-height: 1.6875rem;
+      }
+    }
+  }
+}

--- a/theme/styles/snippets/news-feed.scss
+++ b/theme/styles/snippets/news-feed.scss
@@ -1,4 +1,14 @@
 .NewsFeed {
+  margin-left: $site-padding-x-mobile;
+
+  @include media('xxs-up') {
+    margin-right: $site-padding-x-mobile;
+  }
+
+  @include media('md-up') {
+    margin-left: $site-padding-x-desktop;
+    margin-right: $site-padding-x-desktop;
+  }
 
   &__inner-container {
     

--- a/theme/styles/snippets/news-feed.scss
+++ b/theme/styles/snippets/news-feed.scss
@@ -1,7 +1,7 @@
 .NewsFeed {
   margin-left: $site-padding-x-mobile;
 
-  @include media('xxs-up') {
+  @include media('xs-up') {
     margin-right: $site-padding-x-mobile;
   }
 
@@ -11,7 +11,6 @@
   }
 
   &__inner-container {
-    
     > :last-child {
       border-bottom: 0;
     }  

--- a/theme/styles/snippets/news-feed.scss
+++ b/theme/styles/snippets/news-feed.scss
@@ -7,36 +7,4 @@
       border-bottom: 0;
     }  
   }
-  
-  &__image {
-    width: 3.4375rem;
-    height: 3.4375rem;
-
-    @include media('md-up') {
-      width: 4rem;
-      height: 4rem;
-    }
-  }
-
-  &__row {
-    min-width: 55rem;
-    overflow: hidden;
-    overflow-x: scroll;
-    font-family: $itc-garamond;
-    font-size: 1.125rem;
-    line-height: 1.35rem;
-    letter-spacing: 0.0275rem;
-  
-    @include media('md-up') {
-      font-size: 3.125rem;
-      line-height: 2.8125rem;
-    }
-
-    a {
-      @include media('md-up') {
-        font-size: 1.875rem;
-        line-height: 1.6875rem;
-      }
-    }
-  }
 }

--- a/theme/styles/snippets/news-feed.scss
+++ b/theme/styles/snippets/news-feed.scss
@@ -1,8 +1,7 @@
 .NewsFeed {
 
   &__inner-container {
-    overflow-x: scroll;
-
+    
     > :last-child {
       border-bottom: 0;
     }  

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -1,8 +1,7 @@
-{% render 'home-header' %}
-
 {% assign show_featured_product = collections.frontpage.metafields.accentuate.show_featured_product %}
-
-<div class="grid {% if show_featured_product %} grid--style-first-cell-enlarged {% endif %}">
+{% render 'home-header' %}
+{% render 'news-feed' %}
+<div class="grid {% if show_featured_product %} grid--style-first-cell-enlarged  {% endif %}">
   {% for product in collections.frontpage.products %}
     {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}  
   {% endfor %}


### PR DESCRIPTION
### Description
- Adds Homepage News Feed
- UPDATE: This is now a Markdown Text field in Accentuate. 

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] New feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
#9 
### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://2qdzpaikvh3moqj3-52674822324.shopifypreview.com
pw: nunu

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->
![image](https://user-images.githubusercontent.com/43737723/105911183-8a79e980-5fef-11eb-9ea4-ad338df2a224.png)
![image](https://user-images.githubusercontent.com/43737723/105911224-936abb00-5fef-11eb-88f6-4e362b9f759c.png)


### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
Pt 2: Add the News page. #31 
- Add News Feed Limit field, so they can choose how many rows to show. It is currently hardcoded to be 4 on the homepage.