### PR TITLE
Add Default Page Text Styling

### DIFF
--- a/theme/styles/buttons.scss
+++ b/theme/styles/buttons.scss
@@ -1,4 +1,5 @@
-.button--style-primary {
+.button--style-primary,
+%button--style-primary {
   @extend %transition-shorter;
   border-radius: 0.625rem;
   border: 1px solid color('black');

--- a/theme/styles/buttons.scss
+++ b/theme/styles/buttons.scss
@@ -13,6 +13,21 @@
   }
 }
 
+.button--style-primary-black,
+%button--style-primary-black {
+  @extend %transition-shorter;
+  border-radius: 0.625rem;
+  border: 1px solid color('white');
+  text-transform: uppercase;
+  color: color('white');
+  text-decoration: none;
+
+  &:hover {
+    background-color: color('white');
+    color: color('black');
+  }
+}
+
 .button--style-no-style {
   color: color('inherit');
   text-decoration: none;

--- a/theme/styles/settings/_typography.scss
+++ b/theme/styles/settings/_typography.scss
@@ -8,7 +8,7 @@
 }
 
 /** Sizes */
-.serif-xl, .serif-md, .serif-xs {
+.serif-xxl, .serif-xl, .serif-lg, .serif-md, .serif-xs {
   font-family: $itc-garamond;
   font-weight: 300;
 }
@@ -18,7 +18,19 @@
   font-weight: 300;
 }
 
-.serif-xl {
+.serif-xxl,
+%serif-xxl {
+  font-size: 4.6875rem;
+  line-height: 4.6875rem;
+
+  @include media('md-up') {
+    font-size: 9.375rem;
+    line-height: 9.375rem;
+  }
+}
+
+.serif-xl,
+%serif-xl {
   font-size: 2.5rem;
   line-height: 2.625rem;
 
@@ -28,7 +40,19 @@
   }
 }
 
-.serif-md {
+.serif-lg,
+%serif-lg {
+  font-size: 2.5rem;
+  line-height: 2.625rem;
+
+  @include media('md-up') {
+    font-size: 3.125rem;
+    line-height: 2.8125rem;
+  }
+}
+
+.serif-md,
+%serif-md {
   font-size: 1.125rem;
   line-height: 1.35rem;
   letter-spacing: 0.0275rem;
@@ -66,7 +90,8 @@
   }
 }
 
-.sans-md {
+.sans-md,
+%sans-md {
   font-size: 1.875rem;
   line-height: 1.6875rem;
 
@@ -76,7 +101,8 @@
   }
 }
 
-.sans-sm {
+.sans-sm,
+%sans-sm {
   font-size: 1.875rem;
   line-height: 1.6875rem;
 }

--- a/theme/styles/settings/_typography.scss
+++ b/theme/styles/settings/_typography.scss
@@ -8,7 +8,7 @@
 }
 
 /** Sizes */
-.serif-xxl, .serif-xl, .serif-lg, .serif-md, .serif-xs {
+.serif-mega, .serif-xxl, .serif-xl, .serif-lg, .serif-md, .serif-sm, .serif-xs {
   font-family: $itc-garamond;
   font-weight: 300;
 }
@@ -18,8 +18,7 @@
   font-weight: 300;
 }
 
-.serif-xxl,
-%serif-xxl {
+.serif-mega {
   font-size: 4.6875rem;
   line-height: 4.6875rem;
 
@@ -45,7 +44,7 @@
   font-size: 2.5rem;
   line-height: 2.625rem;
 
-  @include media('md-up') {
+  @include media('lg-up') {
     font-size: 3.125rem;
     line-height: 2.8125rem;
   }
@@ -61,6 +60,12 @@
     font-size: 2.5rem;
     line-height: 2.625rem;
   }
+}
+
+.serif-sm,
+%serif-sm {
+  font-size: 2rem;
+  line-height: 2.1rem;
 }
 
 .serif-xs {
@@ -107,7 +112,8 @@
   line-height: 1.6875rem;
 }
 
-.sans-xs {
+.sans-xs,
+%sans-xs {
   font-size: 1rem;
   line-height: 1.171875rem;
   letter-spacing: 0.0275rem;

--- a/theme/styles/settings/_vars.scss
+++ b/theme/styles/settings/_vars.scss
@@ -5,4 +5,6 @@ $gt-zirkon: GTZirkonLight, sans-serif;
 
 /** Sizing */
 $site-padding-x-mobile: 0.625rem;
+$site-padding-x-mobile-double: 1.25rem;
 $site-padding-x-desktop: 1.25rem;
+$site-padding-x-desktop-double: 2.5rem;

--- a/theme/styles/templates.scss
+++ b/theme/styles/templates.scss
@@ -1,0 +1,1 @@
+@import 'templates/page';

--- a/theme/styles/templates/page.scss
+++ b/theme/styles/templates/page.scss
@@ -1,0 +1,98 @@
+.Page {
+  // &--style-black {
+  //   color: color('white');
+  //   background-color: color('black');
+  // }
+
+  h1, h2, h3, p, ol, ul {
+    font-family: $itc-garamond;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    padding-bottom: 3.125rem;
+  }
+
+  h2 {
+    @extend %serif-xl;
+
+    a {
+      @extend %button--style-primary;
+      font-family: $gt-zirkon;
+      font-size: 2.5rem;
+      line-height: 2.625rem;
+  
+      @include media('md-up') {
+        font-size: 4.0625rem;
+        line-height: 3.65625rem;
+      }
+    }
+  }
+  
+  h3, p, ol, ul {
+    @extend %serif-md;
+  }
+
+  h4, h5 {
+    font-family: $gt-zirkon;
+  }
+
+  h4 {
+    @extend %sans-md;
+    text-transform: uppercase;
+  }
+
+  h5 {
+    @extend %sans-sm;
+  }
+
+  p, ol, ul {
+    margin-bottom: 2rem;
+    
+    @include media('md-up') {
+      margin-bottom: 5.625rem;
+    }
+  }
+
+  ol {
+    margin: 2rem;
+    margin-right: 0;
+  }
+
+  ul {
+    margin: 2rem;
+    margin-right: 0;
+  }
+
+  table {
+    border-collapse: collapse;
+    border-top: 1px solid color('black');
+    border-bottom: 1px solid color('black');
+
+    tr {
+      &:not(last-of-type) {
+        border-bottom: 1px solid color('black');
+      }
+
+      td {
+        padding: 1.6875rem 0;
+        vertical-align: middle;
+
+        &:first-child {
+          font-family: $itc-garamond;
+          @extend %serif-lg;
+        }
+
+        &:last-child {
+          font-family: $gt-zirkon;
+          @extend %sans-sm;
+        }
+      }
+    }
+  }
+
+  &__content {
+    @include media('md-up') {
+      margin-top: 5.625rem;
+    }
+  }
+}

--- a/theme/styles/templates/page.scss
+++ b/theme/styles/templates/page.scss
@@ -1,9 +1,4 @@
 .Page {
-  // &--style-black {
-  //   color: color('white');
-  //   background-color: color('black');
-  // }
-
   h1, h2, h3, p, ol, ul {
     font-family: $itc-garamond;
   }
@@ -13,18 +8,23 @@
   }
 
   h2 {
-    @extend %serif-xl;
+    @extend %serif-sm;
 
     a {
       @extend %button--style-primary;
       font-family: $gt-zirkon;
       font-size: 2.5rem;
       line-height: 2.625rem;
-  
+      
       @include media('md-up') {
         font-size: 4.0625rem;
         line-height: 3.65625rem;
       }
+    }
+
+    @include media('md-up') {
+      font-size: 4.6875rem;
+      line-height: 4.6875rem;
     }
   }
   
@@ -47,9 +47,15 @@
 
   p, ol, ul {
     margin-bottom: 2rem;
-    
+
     @include media('md-up') {
       margin-bottom: 5.625rem;
+    }
+
+    a {
+      &:hover {
+        color: lighten(color('black'), 25%);
+      }
     }
   }
 
@@ -64,9 +70,12 @@
   }
 
   table {
+    display: block;
+    margin: 0 auto;
+    overflow-x: auto;
+    white-space: nowrap;
     border-collapse: collapse;
     border-top: 1px solid color('black');
-    border-bottom: 1px solid color('black');
 
     tr {
       &:not(last-of-type) {
@@ -74,17 +83,36 @@
       }
 
       td {
-        padding: 1.6875rem 0;
+        min-width: calc(50vw - 1.25rem);
         vertical-align: middle;
+        padding: 1.25rem 0;
+
+        @include media('md-up') {
+          padding: 1.6875rem 0;
+          min-width: calc(50vw - 2.5rem);
+        }
 
         &:first-child {
+          padding-right: 2rem;
           font-family: $itc-garamond;
-          @extend %serif-lg;
+          font-size: 1.125rem;
+          line-height: 1.35rem;
+          letter-spacing: 0.0275rem;
+
+          @include media('md-up') {
+            font-size: 3.125rem;
+            line-height: 2.8125rem;
+          }
         }
 
         &:last-child {
           font-family: $gt-zirkon;
-          @extend %sans-sm;
+          @extend %sans-xs;
+
+          @include media('md-up') {
+            font-size: 1.875rem;
+            line-height: 1.6875rem;
+          }
         }
       }
     }
@@ -92,7 +120,51 @@
 
   &__content {
     @include media('md-up') {
-      margin-top: 5.625rem;
+      padding-top: 5.625rem;
+    }
+
+    p, div {
+      img {
+        max-width: calc(100vw - #{$site-padding-x-mobile-double});
+        object-fit: contain;
+        width: 100%;
+        height: 100%;
+
+        @include media('md-up') {
+          max-width: calc(100vw - #{$site-padding-x-desktop-double});
+        }
+      }
     }
   }
+
+  &--style-black {
+    color: color('white');
+    background-color: color('black');
+
+    h2 {  
+      a {
+        @extend %button--style-primary-black;
+      }
+    }
+
+    p, ol, ul {
+      a {
+        &:hover {
+          color: darken(color('white'), 10%);
+        }
+      }
+    }
+
+    table {
+      border-top: 1px solid color('white');
+      border-bottom: 1px solid color('white');
+  
+      tr {
+        &:not(last-of-type) {
+          border-bottom: 1px solid color('white');
+        }
+      }
+    }
+  }
+
 }

--- a/theme/styles/templates/page.scss
+++ b/theme/styles/templates/page.scss
@@ -76,20 +76,21 @@
     white-space: nowrap;
     border-collapse: collapse;
     border-top: 1px solid color('black');
+    border-bottom: 1px solid color('black');
 
     tr {
-      &:not(last-of-type) {
+      &:not(:last-of-type) {
         border-bottom: 1px solid color('black');
       }
 
       td {
-        min-width: calc(50vw - 1.25rem);
+        min-width: calc(50vw - #{$site-padding-x-mobile-double});
         vertical-align: middle;
         padding: 1.25rem 0;
 
         @include media('md-up') {
           padding: 1.6875rem 0;
-          min-width: calc(50vw - 2.5rem);
+          min-width: calc(50vw - #{$site-padding-x-desktop-double});
         }
 
         &:first-child {
@@ -160,7 +161,7 @@
       border-bottom: 1px solid color('white');
   
       tr {
-        &:not(last-of-type) {
+        &:not(:last-of-type) {
           border-bottom: 1px solid color('white');
         }
       }

--- a/theme/templates/page.liquid
+++ b/theme/templates/page.liquid
@@ -1,8 +1,6 @@
 {% assign has_black_background = page.metafields.accentuate.has_black_background %}
 
-{{ has_black_background }}
-
 <div class="Page site-padding-x {% if has_black_background %}Page--style-black {% endif %}">
-  <h1 class="uppercase serif-xxl">{{ page.title }}</h1>
-  <div class="mt2_5">{{ page.content }}</div>  
+  <h1 class="uppercase serif-mega">{{ page.title }}</h1>
+  <div class="Page__content pt2_5 pb2">{{ page.content }}</div>  
 </div>

--- a/theme/templates/page.liquid
+++ b/theme/templates/page.liquid
@@ -1,2 +1,8 @@
-<h1>{{ page.title }}</h1>
-<div>{{ page.content }}</div>
+{% assign has_black_background = page.metafields.accentuate.has_black_background %}
+
+{{ has_black_background }}
+
+<div class="Page site-padding-x {% if has_black_background %}Page--style-black {% endif %}">
+  <h1 class="uppercase serif-xxl">{{ page.title }}</h1>
+  <div class="mt2_5">{{ page.content }}</div>  
+</div>


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- Adds Default Page Rich Text Styling (h1, h2, h3, table, etc)
- Does not add styling for images with captions.

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] New feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
Closes #29 
Closes #33 
Closes #35 

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://v1pit9s77i0c9lvh-52674822324.shopifypreview.com/pages/about
https://v1pit9s77i0c9lvh-52674822324.shopifypreview.com/pages/default-page-style-guide

pw: nunu
### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->
![image](https://user-images.githubusercontent.com/43737723/105738760-ffb8c200-5efc-11eb-9453-6c0cdfee7d42.png)
![image](https://user-images.githubusercontent.com/43737723/105738815-10693800-5efd-11eb-9e41-4361346ac613.png)

![image](https://user-images.githubusercontent.com/43737723/105738782-06dfd000-5efd-11eb-951c-6424261ad85e.png)

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
- Images with caption #28 #36 