### PR TITLE
Add Related Products to Product Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## About The Project
 
-//TO-DO: Add project description
+This is a relaunch of the old XXXI as a new community space for hosting events, workshops, shared / sharing knowledge, and store.
 
 ### The Stack
 
@@ -34,6 +34,7 @@ Here are the major frameworks, programming languages, software and libraries we 
 - [Liquid](https://shopify.github.io/liquid/)
 - [Basement CSS](https://basement.sanctuary.computer/)
 - Shopify Bookings
+- [Accentuate Custom Fields for Shopify](https://www.accentuate.io/)
 
 #### Design
 

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -25,15 +25,20 @@
 //* Product Grid */
 .grid {
   display: grid;
-    padding-left: 0.125rem;
-    padding-right: 0.125rem;
-    gap: 0.125rem;
-    grid-template-columns: 1fr;
+  padding-left: 0.125rem;
+  padding-right: 0.125rem;
+  gap: 0.125rem;
+  grid-template-columns: 1fr;
 
-    @include media('md-up') {
-      grid-template-columns: repeat(3, 1fr);
-    }
+  @include media('md-up') {
+    grid-template-columns: repeat(3, 1fr);
+  }
 
+  &--style-related-products {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  
   &--style-featured-product {
     @include media('lg-up') {
       > :first-child {

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -34,12 +34,12 @@
     grid-template-columns: repeat(3, 1fr);
   }
 
-  &--style-related-products {
+  &--style-padding-x-0 {
     padding-left: 0;
     padding-right: 0;
   }
   
-  &--style-featured-product {
+  &--style-first-cell-enlarged {
     @include media('lg-up') {
       > :first-child {
         grid-column: 1/3;

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -2,7 +2,7 @@
 
 {% assign show_featured_product = collections.frontpage.metafields.accentuate.show_featured_product %}
 
-<div class="grid {% if show_featured_product %} grid--style-featured-product {% endif %}">
+<div class="grid {% if show_featured_product %} grid--style-first-cell-enlarged {% endif %}">
   {% for product in collections.frontpage.products %}
     {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}  
   {% endfor %}

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -39,7 +39,7 @@
     <div class="site-padding-x uppercase color-white serif-xl pb2_5">{{ related_products_heading }}</div>
   {% endif %}
 
-  <div class="grid grid--style-related-products bg-color-white pt_125">
+  <div class="grid grid--style-padding-x-0 bg-color-white pt_125">
     {% for related_products_handle in related_products_handles %}
       {% render 'product-grid-item', current_product: all_products[related_products_handle] %}  
     {% endfor %}

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -2,36 +2,38 @@
 {% assign featured_image = current_variant.featured_image | default: product.featured_image %}
 {% assign related_products_heading = product.metafields.accentuate.related_products_heading %}
 {% assign related_products_handles = product.metafields.accentuate.related_products | split: '|' %}
-<div class="Product pt_625 site-padding-x bg-color-black">
-  <h1 class="uppercase serif-xl color-white">{{ product.title }}</h1>
-  <p class="uppercase sans-sm color-white">{{ product.vendor }}</p>
+
+<div class="Product bg-color-black">
   <img src="{{ featured_image | img_url: 'large' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg">
-{% for image in product.images %}
-  <a href="{{ image.src | img_url: 'large' }}">
-    <img src="{{ image.src | img_url: 'compact' }}" alt="{{ image.alt | escape }}">
-  </a>
-{% endfor %}
-<form action="/cart/add" method="post" enctype="multipart/form-data" id="AddToCartForm">
-  <select name="id" id="productSelect">
-    {% for variant in product.variants %}
-      {% if variant.available %}
-        <option value="{{ variant.id }}">
-          {{ variant.title }} - {{ variant.price | money_with_currency }}
-        </option>
-      {% else %}
-        <option disabled="disabled">
-          {{ variant.title }} - sold out
-        </option>
-      {% endif %}
-    {% endfor %}
-  </select>
-  {{ current_variant.price | money }}
-  <label for="Quantity">quantity</label>
-  <input type="number" id="Quantity" name="quantity" value="1" min="1">
-  <button type="submit" name="add" id="AddToCart">Add to cart</button>
-</form>
-<div>{{ product.description }}</div>
-{% if related_products_heading %}
+  {% for image in product.images %}
+    <a href="{{ image.src | img_url: 'large' }}">
+      <img src="{{ image.src | img_url: 'compact' }}" alt="{{ image.alt | escape }}">
+    </a>
+  {% endfor %}
+  <h1 class="color-white">{{ product.title }}</h1>
+
+  <form action="/cart/add" method="post" enctype="multipart/form-data" id="AddToCartForm">
+    <select name="id" id="productSelect">
+      {% for variant in product.variants %}
+        {% if variant.available %}
+          <option value="{{ variant.id }}">
+            {{ variant.title }} - {{ variant.price | money_with_currency }}
+          </option>
+        {% else %}
+          <option disabled="disabled">
+            {{ variant.title }} - sold out
+          </option>
+        {% endif %}
+      {% endfor %}
+    </select>
+    {{ current_variant.price | money }}
+    <label for="Quantity">quantity</label>
+    <input type="number" id="Quantity" name="quantity" value="1" min="1">
+    <button type="submit" name="add" id="AddToCart">Add to cart</button>
+  </form>
+  <div>{{ product.description }}</div>
+
+  {% if related_products_heading %}
     <div class="uppercase color-white serif-xl pb2_5">{{ related_products_heading }}</div>
   {% endif %}
 
@@ -41,4 +43,3 @@
     {% endfor %}
   </div>
 </div>
-

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -3,15 +3,17 @@
 {% assign related_products_heading = product.metafields.accentuate.related_products_heading %}
 {% assign related_products_handles = product.metafields.accentuate.related_products | split: '|' %}
 
-<div class="Product bg-color-black">
+<div class="Product pt_625 bg-color-black">
+  <div class="site-padding-x">
+    <h1 class="uppercase serif-xl color-white">{{ product.title }}</h1>
+    <p class="uppercase sans-sm color-white">{{ product.vendor }}</p>
+  </div>
   <img src="{{ featured_image | img_url: 'large' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg">
   {% for image in product.images %}
     <a href="{{ image.src | img_url: 'large' }}">
       <img src="{{ image.src | img_url: 'compact' }}" alt="{{ image.alt | escape }}">
     </a>
   {% endfor %}
-  <h1 class="color-white">{{ product.title }}</h1>
-
   <form action="/cart/add" method="post" enctype="multipart/form-data" id="AddToCartForm">
     <select name="id" id="productSelect">
       {% for variant in product.variants %}
@@ -34,7 +36,7 @@
   <div>{{ product.description }}</div>
 
   {% if related_products_heading %}
-    <div class="uppercase color-white serif-xl pb2_5">{{ related_products_heading }}</div>
+    <div class="site-padding-x uppercase color-white serif-xl pb2_5">{{ related_products_heading }}</div>
   {% endif %}
 
   <div class="grid grid--style-related-products bg-color-white pt_125">

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -1,6 +1,8 @@
 {% assign current_variant = product.selected_or_first_available_variant %}
 {% assign featured_image = current_variant.featured_image | default: product.featured_image %}
-<div class="pt_625 site-padding-x bg-color-black">
+{% assign related_products_heading = product.metafields.accentuate.related_products_heading %}
+{% assign related_products_handles = product.metafields.accentuate.related_products | split: '|' %}
+<div class="Product pt_625 site-padding-x bg-color-black">
   <h1 class="uppercase serif-xl color-white">{{ product.title }}</h1>
   <p class="uppercase sans-sm color-white">{{ product.vendor }}</p>
   <img src="{{ featured_image | img_url: 'large' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg">
@@ -29,6 +31,14 @@
   <button type="submit" name="add" id="AddToCart">Add to cart</button>
 </form>
 <div>{{ product.description }}</div>
+{% if related_products_heading %}
+    <div class="uppercase color-white serif-xl pb2_5">{{ related_products_heading }}</div>
+  {% endif %}
 
+  <div class="grid grid--style-related-products bg-color-white pt_125">
+    {% for related_products_handle in related_products_handles %}
+      {% render 'product-grid-item', current_product: all_products[related_products_handle] %}  
+    {% endfor %}
+  </div>
 </div>
 


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- Adds Related Products to Product Page (using accentuate custom metafields)

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] New feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
#17 
### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://zzcua7nmw4nmdue0-52674822324.shopifypreview.com
pw: nunu
Click on Type Design 1 (first product on the homepage)

### Applicable screenshots:
In Shopify:
![image](https://user-images.githubusercontent.com/43737723/105769915-25a58d00-5f24-11eb-9b43-3b0fdc5647f1.png)

<!--- When appropriate, upload screenshots. -->
![image](https://user-images.githubusercontent.com/43737723/105769380-5b964180-5f23-11eb-874b-bade1bf44b12.png)
![image](https://user-images.githubusercontent.com/43737723/105769406-6355e600-5f23-11eb-98dd-e08ddecc1efa.png)

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
