### PR TITLE
Add Knowledge Area Header and Knowledge Area Markdown

### DIFF
--- a/theme/snippets/knowledge-area-header.liquid
+++ b/theme/snippets/knowledge-area-header.liquid
@@ -1,18 +1,18 @@
-{% assign heading_image = shop.metafields.globals.knowledge_area_heading_image[knowledge_area.index] %}
-{% assign author = shop.metafields.globals.knowledge_area_author[knowledge_area.index] %}
+{% assign author = shop.metafields.globals['knowledge_area_author'][module.index]%}
+{% assign header_images = shop.metafields.globals['knowledge_area_header_image'][module.index] %}
+  {% for image in header_images %} 
+    {% assign header_image = image %}
+  {% endfor %}
 
-<div class="KnowledgeAreaHeader border-thick-black flex flex-col p1_25">
+<div class="KnowledgeAreaHeader border-thick-black flex flex-col p1_25 mb1_875">
   <div class="flex flex-col md:flex-row">
-    {% if heading_image %}
-      {% for value in page.metafields.accentuate.knowledge_area_heading_image %} 
-        {% assign image = page.metafields.accentuate.knowledge_area_heading_image[forloop.index0] %}
+    {% if header_image %}
           <div class="KnowledgeAreaHeader__image-container col-5 md:col-2 radius-lg md:mr1_5 mb1_25 md:mb0">
-            <img class="w100 h100 fit-cover radius-lg" src="{{ image.src }}" alt="{{ image.alt }}"/>
+            <img class="w100 h100 fit-cover radius-lg" src="{{ header_image.src }}" alt="{{ header_image.alt }}"/>
           </div>
-      {% endfor %} 
     {% endif %}
     <div class="flex col-12 md:col-10">
-      <h1 class="KnowledgeAreaHeader__title flex items-center justify-center hyphens sans-lg sans-serif uppercase border-black border-black radius-lg p_625">{{ page.title }}</h1>
+      <h1 class="KnowledgeAreaHeader__title flex items-center justify-center hyphens sans-lg sans-serif uppercase border-black border-black radius-lg p_625">{{ title }}</h1>
     </div>
   </div>
   {% if author %}

--- a/theme/snippets/knowledge-area-header.liquid
+++ b/theme/snippets/knowledge-area-header.liquid
@@ -1,0 +1,21 @@
+{% assign heading_image = page.metafields.accentuate.knowledge_area_heading_image %}
+{% assign author = page.metafields.accentuate.knowledge_area_author %}
+
+<div class="flex flex-col p1_25">
+  <div class="flex flex-col md:flex-row">
+    {% if heading_image %}
+      {% for value in page.metafields.accentuate.knowledge_area_heading_image %} 
+        {% assign image = page.metafields.accentuate.knowledge_area_heading_image[forloop.index0] %}
+          <div class="KnowledgeAreaHeader__image-container col-5 md:col-2 radius-lg md:mr1_5">
+            <img class="w100 h100 fit-cover radius-lg" src="{{ image.src }}" alt="{{ image.alt}}"/>
+          </div>
+      {% endfor %} 
+    {% endif %}
+    <div class="flex col-12 md:col-10">
+      <h1 class="KnowledgeAreaHeader__title flex items-center justify-center hyphens sans-lg sans-serif uppercase border-black border-black radius-lg">{{ page.title }}</h1>
+    </div>
+  </div>
+  {% if author %}
+    <span class="pt1_875 md:pt2_5 sans-xs uppercase">Knowledge area by {{ author }}</span>
+  {% endif %}
+</div>

--- a/theme/snippets/knowledge-area-header.liquid
+++ b/theme/snippets/knowledge-area-header.liquid
@@ -1,18 +1,18 @@
 {% assign heading_image = page.metafields.accentuate.knowledge_area_heading_image %}
 {% assign author = page.metafields.accentuate.knowledge_area_author %}
 
-<div class="flex flex-col p1_25">
+<div class="flex flex-col p1_25 border-left-black border-bottom-black border-right-black">
   <div class="flex flex-col md:flex-row">
     {% if heading_image %}
       {% for value in page.metafields.accentuate.knowledge_area_heading_image %} 
         {% assign image = page.metafields.accentuate.knowledge_area_heading_image[forloop.index0] %}
-          <div class="KnowledgeAreaHeader__image-container col-5 md:col-2 radius-lg md:mr1_5">
-            <img class="w100 h100 fit-cover radius-lg" src="{{ image.src }}" alt="{{ image.alt}}"/>
+          <div class="KnowledgeAreaHeader__image-container col-5 md:col-2 radius-lg md:mr1_5 mb1_25 md:mb0">
+            <img class="w100 h100 fit-cover radius-lg" src="{{ image.src }}" alt="{{ image.alt }}"/>
           </div>
       {% endfor %} 
     {% endif %}
     <div class="flex col-12 md:col-10">
-      <h1 class="KnowledgeAreaHeader__title flex items-center justify-center hyphens sans-lg sans-serif uppercase border-black border-black radius-lg">{{ page.title }}</h1>
+      <h1 class="KnowledgeAreaHeader__title flex items-center justify-center hyphens sans-lg sans-serif uppercase border-black border-black radius-lg p_625">{{ page.title }}</h1>
     </div>
   </div>
   {% if author %}

--- a/theme/snippets/knowledge-area-header.liquid
+++ b/theme/snippets/knowledge-area-header.liquid
@@ -1,7 +1,7 @@
-{% assign heading_image = page.metafields.accentuate.knowledge_area_heading_image %}
-{% assign author = page.metafields.accentuate.knowledge_area_author %}
+{% assign heading_image = shop.metafields.globals.knowledge_area_heading_image[knowledge_area.index] %}
+{% assign author = shop.metafields.globals.knowledge_area_author[knowledge_area.index] %}
 
-<div class="flex flex-col p1_25 border-left-black border-bottom-black border-right-black">
+<div class="KnowledgeAreaHeader border-thick-black flex flex-col p1_25">
   <div class="flex flex-col md:flex-row">
     {% if heading_image %}
       {% for value in page.metafields.accentuate.knowledge_area_heading_image %} 

--- a/theme/snippets/knowledge-area-markdown.liquid
+++ b/theme/snippets/knowledge-area-markdown.liquid
@@ -1,0 +1,3 @@
+<div class="KnowledgeAreaMarkdown site-padding-x md:col-9">
+  {{ markdown }}
+</div>

--- a/theme/styles/_snippets.scss
+++ b/theme/styles/_snippets.scss
@@ -5,3 +5,4 @@
 @import 'snippets/news-feed-item';
 @import 'snippets/nav';
 @import 'snippets/knowledge-area-header.scss';
+@import 'snippets/knowledge-area-markdown.scss';

--- a/theme/styles/_snippets.scss
+++ b/theme/styles/_snippets.scss
@@ -4,3 +4,4 @@
 @import 'snippets/news-feed';
 @import 'snippets/news-feed-item';
 @import 'snippets/nav';
+@import 'snippets/knowledge-area-header.scss';

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -48,6 +48,10 @@
   display: inline-block;
 }
 
+.border-black {
+  border: 1px solid color('black');
+}
+
 //* Product Grid */
 .grid {
   display: grid;
@@ -77,4 +81,8 @@
       }
     }
   }
+}
+
+.hyphens {
+  hyphens: auto;
 }

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -52,6 +52,10 @@
   border: 1px solid color('black');
 }
 
+.border-thick-black {
+  border: 2px solid color('black');
+}
+
 .border-left-black {
   border-left: 1px solid color('black');
 }

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -52,6 +52,18 @@
   border: 1px solid color('black');
 }
 
+.border-left-black {
+  border-left: 1px solid color('black');
+}
+
+.border-right-black {
+  border-right: 1px solid color('black');
+}
+
+.border-bottom-black {
+  border-bottom: 1px solid color('black');
+}
+
 //* Product Grid */
 .grid {
   display: grid;

--- a/theme/styles/settings/_radius.scss
+++ b/theme/styles/settings/_radius.scss
@@ -2,7 +2,8 @@ $border-radius: (
   'none': 0rem,
   'xs': 0.375rem,
   'sm': 0.625rem,
-  'md': 0.75rem
+  'md': 0.75rem,
+  'lg': 0.9375rem,
 );
 
 @function radius($radius) {

--- a/theme/styles/snippets/knowledge-area-header.scss
+++ b/theme/styles/snippets/knowledge-area-header.scss
@@ -1,4 +1,5 @@
 .KnowledgeAreaHeader {
+
   &__title {
     @include media('lg-up') {
       font-size: 9.375rem;

--- a/theme/styles/snippets/knowledge-area-header.scss
+++ b/theme/styles/snippets/knowledge-area-header.scss
@@ -1,0 +1,19 @@
+.KnowledgeAreaHeader {
+  &__image-container {
+ 
+    // > img {
+    //   max-width: 11.25rem;
+
+    //   @include media('md-up') {
+    //     max-width: 17.6875rem;
+    //   }
+    // }
+  }
+
+  &__title {
+    @include media('lg-up') {
+      font-size: 9.375rem;
+      line-height: 8.4375rem;
+    }
+  }
+}

--- a/theme/styles/snippets/knowledge-area-header.scss
+++ b/theme/styles/snippets/knowledge-area-header.scss
@@ -1,15 +1,4 @@
 .KnowledgeAreaHeader {
-  &__image-container {
- 
-    // > img {
-    //   max-width: 11.25rem;
-
-    //   @include media('md-up') {
-    //     max-width: 17.6875rem;
-    //   }
-    // }
-  }
-
   &__title {
     @include media('lg-up') {
       font-size: 9.375rem;

--- a/theme/styles/snippets/knowledge-area-markdown.scss
+++ b/theme/styles/snippets/knowledge-area-markdown.scss
@@ -1,0 +1,31 @@
+.KnowledgeAreaMarkdown {
+  padding-bottom: 3.125rem;
+    
+  @include media ('lg-up') {
+    padding-bottom: 12.5rem;
+  }
+
+  h1, h2, h3, p {
+    font-family: $itc-garamond;
+  }
+
+  h2 {
+    font-size: 2.5rem;
+    line-height: 2.625rem;
+    padding-bottom: 2.5rem;
+
+    @include media('lg-up') {
+      font-size: 3.125rem;
+      line-height: 2.8125rem;
+    }
+  }
+
+  p {
+    @extend %serif-sm;
+
+    @include media('lg-up') {
+      font-size: 2.5rem;
+      line-height: 2.625rem;
+    }
+  }
+}

--- a/theme/styles/templates.scss
+++ b/theme/styles/templates.scss
@@ -1,2 +1,3 @@
 @import 'templates/page';
 @import 'templates/news';
+@import 'templates/knowledge-area';

--- a/theme/styles/templates/knowledge-area.scss
+++ b/theme/styles/templates/knowledge-area.scss
@@ -1,0 +1,3 @@
+.KnowledgeArea {
+
+}

--- a/theme/templates/page.knowledge-areas.liquid
+++ b/theme/templates/page.knowledge-areas.liquid
@@ -1,3 +1,5 @@
 <div class="KnowledgeArea">
-  {% render 'knowledge-area-header' %}
+  {% for knowledge_area_content in page.metafields.accentuate.knowledge_area_content.references %}
+    {{ knowledge_area_content }}
+  {% endfor %}
 </div>

--- a/theme/templates/page.knowledge-areas.liquid
+++ b/theme/templates/page.knowledge-areas.liquid
@@ -1,3 +1,3 @@
-TEST
-<h1>{{ page.title }}</h1>
-<div>{{ page.content }}</div>
+<div class="KnowledgeArea">
+  {% render 'knowledge-area-header' %}
+</div>

--- a/theme/templates/page.knowledge-areas.liquid
+++ b/theme/templates/page.knowledge-areas.liquid
@@ -1,0 +1,3 @@
+TEST
+<h1>{{ page.title }}</h1>
+<div>{{ page.content }}</div>

--- a/theme/templates/page.knowledge-areas.liquid
+++ b/theme/templates/page.knowledge-areas.liquid
@@ -3,13 +3,8 @@
 <div class="KnowledgeArea">
   {% for module in content_modules %}
     {% assign referenced_fields = shop.metafields.acf_settings.global.fields | where: "section_name", module.section %}
-    {% comment %}
-      This block switch renders different snippets depending on the section name.
-    {% endcomment %}
-
     {% assign section = module.section %}
     {% case section %}
-
     {% when 'knowledge_area_header' %}
       {% render 'knowledge-area-header' title: page.title module: module %}
     {% when 'knowledge_area_overview' %} 

--- a/theme/templates/page.knowledge-areas.liquid
+++ b/theme/templates/page.knowledge-areas.liquid
@@ -1,5 +1,21 @@
+{% assign content_modules = page.metafields.accentuate.knowledge_area_content.references %}
+
 <div class="KnowledgeArea">
-  {% for knowledge_area_content in page.metafields.accentuate.knowledge_area_content.references %}
-    {{ knowledge_area_content }}
+  {% for module in content_modules %}
+    {% assign referenced_fields = shop.metafields.acf_settings.global.fields | where: "section_name", module.section %}
+    {% comment %}
+      This block switch renders different snippets depending on the section name.
+    {% endcomment %}
+
+    {% assign section = module.section %}
+    {% case section %}
+
+    {% when 'knowledge_area_header' %}
+      {% render 'knowledge-area-header' title: page.title module: module %}
+    {% when 'knowledge_area_overview' %} 
+      {% render 'knowledge-area-markdown' markdown: shop.metafields.globals['knowledge_area_overview'][module.index].html %}    
+    {% when 'knowledge_area_tips' %}   
+      {% render 'knowledge-area-markdown' markdown: shop.metafields.globals['knowledge_area_tips'][module.index].html %}
+    {% endcase %}
   {% endfor %}
 </div>


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- Added a tiny bit of styling to the placeholder Nav so it's nicer to look at!
- Adds Knowledge Area page template
- Adds `Knowledge Area Header` and `Knowledge Area Markdown` snippets
- When the user creates a new page, they click on the `Knowledge Areas template`. Pages using the `Knowledge Areas template` have access to the Knowledge Area Accentuate custom fields. 

**What the Accentuate global values look like (Editors will need to create these in globals, and then reference them in a Page's Accentuate field):**
![image](https://user-images.githubusercontent.com/43737723/106789895-74d07980-6618-11eb-9c14-8200f9ef61f7.png)

![image](https://user-images.githubusercontent.com/43737723/106680162-bbc05f80-6583-11eb-8391-39989781efc9.png)

**The editors will reference these global values here, in the Page's Accentuate fields:**
![image](https://user-images.githubusercontent.com/43737723/106680250-e3afc300-6583-11eb-9fbf-68d8d6d594bf.png)


### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] New feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
#21 
Closes #23

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://b7porruvzd1f1rm4-52674822324.shopifypreview.com/pages/birding
pw: nunu

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->
![image](https://user-images.githubusercontent.com/43737723/106791128-22905800-661a-11eb-8223-2fcea9d32269.png)

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
