### PR TITLE
Add News Page

### DIFF
--- a/theme/snippets/news-feed-item.liquid
+++ b/theme/snippets/news-feed-item.liquid
@@ -2,7 +2,6 @@
   <div class="flex col-1 md:mx_75">
     <img class="NewsFeedItem__image fit-contain w100 h100" src="{{ image_src }}" alt="{{ image_alt }}"/>
   </div>
-
   <div class="flex items-center justify-between col-11">
     <span class="NewsFeedItem__body serif px1">{{ body.html }}</span>
     <span class="NewsFeedItem__third-column sans-xs sans-serif md:pl2">{{ third_column.html }}</span>

--- a/theme/snippets/news-feed-item.liquid
+++ b/theme/snippets/news-feed-item.liquid
@@ -1,4 +1,4 @@
-<div class="NewsFeedItem overflow-hidden overflow-x-scroll flex items-center border-bottom-black py1_25 md:py_75 xs:pr0">
+<div class="NewsFeedItem overflow-hidden overflow-x-scroll flex items-center border-thick-bottom-black py1_25 md:py_75 xs:pr0">
   <div class="flex col-1 md:mx_75">
     <img class="NewsFeedItem__image fit-contain w100 h100" src="{{ image_src }}" alt="{{ image_alt }}"/>
   </div>

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -8,9 +8,7 @@
     {% render 'news-feed-item', image_src: current_thumbnail.src image_alt: current_thumbnail.alt body: value, third_column: shop.metafields.accentuate.news_feed_item_third_column[forloop.index0] %}
   {% endfor %}
   </div>
-
   {% if is_limited %}
     <a class="uppercase serif-xl pt2 md:pt5 pb3 hover-lighten-black" href="/pages/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>
   {% endif %}
-
 </div>

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,5 +1,5 @@
 <div class="NewsFeed flex flex-col">
-  <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black">
+  <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-thick-top-black border-thick-bottom-black">
     {% for value in shop.metafields.accentuate.news_feed_item_body limit: limit %} 
     {% assign multi_thumbnails = shop.metafields.accentuate.news_feed_item_thumbnail[forloop.index0] %}
     {% for thumbnail in multi_thumbnails %} 

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,13 +1,16 @@
 <div class="NewsFeed flex flex-col">
   <div class="NewsFeed__inner-container overflow-x-scroll flex flex-col border-top-black border-bottom-black">
-  {% for value in shop.metafields.accentuate.news_feed_item_body limit:4 %} 
+    {% for value in shop.metafields.accentuate.news_feed_item_body limit: limit %} 
     {% assign multi_thumbnails = shop.metafields.accentuate.news_feed_item_thumbnail[forloop.index0] %}
     {% for thumbnail in multi_thumbnails %} 
       {% assign current_thumbnail = thumbnail %}
     {% endfor %}
     {% render 'news-feed-item', image_src: current_thumbnail.src image_alt: current_thumbnail.alt body: value, third_column: shop.metafields.accentuate.news_feed_item_third_column[forloop.index0] %}
-  {% endfor %} 
+  {% endfor %}
   </div>
 
-  <a class="uppercase serif-xl pt2 md:pt5 pb3 hover-lighten-black" href="/pages/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>
+  {% if is_limited %}
+    <a class="uppercase serif-xl pt2 md:pt5 pb3 hover-lighten-black" href="/pages/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>
+  {% endif %}
+
 </div>

--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -8,7 +8,7 @@
     {% render 'news-feed-item', image_src: current_thumbnail.src image_alt: current_thumbnail.alt body: value, third_column: shop.metafields.accentuate.news_feed_item_third_column[forloop.index0] %}
   {% endfor %}
   </div>
-  {% if is_limited %}
+  {% if limit %}
     <a class="uppercase serif-xl pt2 md:pt5 pb3 hover-lighten-black" href="/pages/news" aria-label="{{ 'snippets.news_feed.see_more_link.aria_label' | t }}">{{ 'snippets.news_feed.see_more_link.text' | t }}</a>
   {% endif %}
 </div>

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -28,8 +28,16 @@
   border-top: 1px solid color('black');
 }
 
+.border-thick-top-black {
+  border-top: 2px solid color('black');
+}
+
 .border-bottom-black {
   border-bottom: 1px solid color('black');
+}
+
+.border-thick-bottom-black {
+  border-bottom: 2px solid color('black');
 }
 
 .dot {

--- a/theme/styles/snippets/news-feed-item.scss
+++ b/theme/styles/snippets/news-feed-item.scss
@@ -27,6 +27,7 @@
       min-width: 55rem;
     }
   }
+
   &__third-column p, &__third-column p a {
     @include media('md-up') {
       font-size: 1.875rem;

--- a/theme/styles/snippets/news-feed-item.scss
+++ b/theme/styles/snippets/news-feed-item.scss
@@ -27,7 +27,6 @@
       min-width: 55rem;
     }
   }
-
   &__third-column p, &__third-column p a {
     @include media('md-up') {
       font-size: 1.875rem;

--- a/theme/styles/snippets/news-feed.scss
+++ b/theme/styles/snippets/news-feed.scss
@@ -12,7 +12,7 @@
 
   &__inner-container {
     > :last-child {
-      border-bottom: 0;
+      border-bottom: 0!important;
     }  
   }
 }

--- a/theme/styles/templates.scss
+++ b/theme/styles/templates.scss
@@ -1,1 +1,2 @@
 @import 'templates/page';
+@import 'templates/news';

--- a/theme/styles/templates/news.scss
+++ b/theme/styles/templates/news.scss
@@ -1,0 +1,9 @@
+.News {
+  &__content {
+    margin-top: -0.75rem;
+
+    @include media('lg-up') {
+      margin-top: -2rem;
+    }
+  }
+}

--- a/theme/styles/templates/news.scss
+++ b/theme/styles/templates/news.scss
@@ -1,9 +1,9 @@
 .News {
   &__content {
-    margin-top: -0.75rem;
+    margin-top: -1.5rem;
 
     @include media('lg-up') {
-      margin-top: -2rem;
+      margin-top: -3rem;
     }
   }
 }

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -1,6 +1,6 @@
 {% assign show_featured_product = collections.frontpage.metafields.accentuate.show_featured_product %}
 {% render 'home-header' %}
-{% render 'news-feed' %}
+{% render 'news-feed' is_limited: true, limit: 4 %}
 <div class="grid {% if show_featured_product %} grid--style-first-cell-enlarged  {% endif %}">
   {% for product in collections.frontpage.products %}
     {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}  

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -1,6 +1,7 @@
 {% assign show_featured_product = collections.frontpage.metafields.accentuate.show_featured_product %}
+{% assign news_feed_limit = shop.metafields.accentuate.news_feed_homepage_limit %}
 {% render 'home-header' %}
-{% render 'news-feed' is_limited: true, limit: 4 %}
+{% render 'news-feed' is_limited: true, limit: news_feed_limit %}
 <div class="grid {% if show_featured_product %} grid--style-first-cell-enlarged  {% endif %}">
   {% for product in collections.frontpage.products %}
     {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}  

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -1,7 +1,7 @@
 {% assign show_featured_product = collections.frontpage.metafields.accentuate.show_featured_product %}
 {% assign news_feed_limit = shop.metafields.accentuate.news_feed_homepage_limit %}
 {% render 'home-header' %}
-{% render 'news-feed' is_limited: true, limit: news_feed_limit %}
+{% render 'news-feed' limit: news_feed_limit %} 
 <div class="grid {% if show_featured_product %} grid--style-first-cell-enlarged  {% endif %}">
   {% for product in collections.frontpage.products %}
     {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}  

--- a/theme/templates/page.news.liquid
+++ b/theme/templates/page.news.liquid
@@ -1,2 +1,6 @@
-<h1 class="uppercase serif-mega site-padding-x">{{ page.title }}</h1>
-{% render 'news-feed', is_limited: false, limit: 5000 %}
+<div class="News">
+  <h1 class="uppercase serif-mega site-padding-x">{{ page.title }}</h1>
+  <div class="News__content">
+    {% render 'news-feed', is_limited: false %}
+  </div>
+</div>

--- a/theme/templates/page.news.liquid
+++ b/theme/templates/page.news.liquid
@@ -1,0 +1,2 @@
+<h1 class="uppercase serif-mega site-padding-x">{{ page.title }}</h1>
+{% render 'news-feed', is_limited: false, limit: 5000 %}

--- a/theme/templates/page.news.liquid
+++ b/theme/templates/page.news.liquid
@@ -1,6 +1,7 @@
+{% assign news_feed_limit = shop.metafields.accentuate.news_feed_on_news_page_limit %}
 <div class="News">
   <h1 class="uppercase serif-mega site-padding-x">{{ page.title }}</h1>
   <div class="News__content">
-    {% render 'news-feed', is_limited: false %}
+    {% render 'news-feed' limit: limit %}
   </div>
 </div>


### PR DESCRIPTION
### Description
- Adds News page template
- Small modifications to `news-feed.liquid` so that the news feed limit changes depending on the page. The home page feed should be limited to 4 with a "See More" button, while the news page feed should be unlimited. 

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] New feature
- [x] Update to an existing feature

### Motivation for PR
#32 
<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://hayoijrzxmxvv0ly-52674822324.shopifypreview.com/pages/news
pw: nunu
### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->
![image](https://user-images.githubusercontent.com/43737723/106040922-bdc88100-60a0-11eb-8e7d-c35f0a3fe3e6.png)

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
