### PR TITLE
Add Product Description Markdown and Product Info Bar

### DIFF
--- a/theme/snippets/knowledge-area-markdown.liquid
+++ b/theme/snippets/knowledge-area-markdown.liquid
@@ -1,3 +1,5 @@
+{% comment %} TO-DO: Have Knowledge Areas use the Markdown snippet. {% endcomment %}
+
 <div class="KnowledgeAreaMarkdown site-padding-x md:col-9">
   {{ markdown }}
 </div>

--- a/theme/snippets/markdown.liquid
+++ b/theme/snippets/markdown.liquid
@@ -1,0 +1,3 @@
+<div class="Markdown color-black {{classes}} {% if variant == 'black-bg' %}Markdown--style-black-bg color-white{% endif %}">
+    {{ markdown }}
+</div>

--- a/theme/snippets/markdown.liquid
+++ b/theme/snippets/markdown.liquid
@@ -1,3 +1,3 @@
-<div class="Markdown color-black {{classes}} {% if variant == 'black-bg' %}Markdown--style-black-bg color-white{% endif %}">
+<div class="Markdown color-black {{ classes }} {% if variant == 'black-bg' %}Markdown--style-black-bg color-white{% endif %}">
     {{ markdown }}
 </div>

--- a/theme/snippets/nav.liquid
+++ b/theme/snippets/nav.liquid
@@ -29,7 +29,6 @@
       </a>
     </div>
     <a class="uppercase py1_875" href="/" aria-label="{{ 'snippets.nav.links.home_link.aria_label' | t }}">{{ 'snippets.nav.links.home_link.text' | t }}</a>
-    <a class="uppercase pb1_875" href="/" aria-label="{{ 'snippets.nav.links.knowledge_areas_link.aria_label' | t }}">{{ 'snippets.nav.links.knowledge_areas_link.text' | t }}</a>
     <a class="uppercase pb1_875" href="/pages/about" aria-label="{{ 'snippets.nav.links.about_link.aria_label' | t }}">{{ 'snippets.nav.links.about_link.text' | t }}</a>
     <a class="uppercase" href="/pages/news" aria-label="{{ 'snippets.nav.links.news_link.aria_label' | t }}">{{ 'snippets.nav.links.news_link.text' | t }}</a>
   </div>

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -26,7 +26,7 @@
 
     <div class="ProductGridItem__details absolute r0 b0 p_625 sans-xxs uppercase flex justify-between w100">
       <span class="flex items-center">
-        <span class="dot mr_25"></span>
+        <span class="dot-sm mr_25"></span>
         <span>{{ current_product.type }}</span>
       </span>
       <span class="radius-xs border-white p_25">Type Design</span>

--- a/theme/snippets/product-info-bar.liquid
+++ b/theme/snippets/product-info-bar.liquid
@@ -1,0 +1,21 @@
+{% comment %} TO-DO: Adjust or replace Tags, Add "Add to Cart" functionality {% endcomment %}
+
+<div class="ProductInfoBar border-thick-top-white border-thick-bottom-white flex flex-col md:flex-row justify-between">
+  <span class="ProductInfoBar__product-details col-12 md:col-7 flex items-center sans-sm uppercase color-white border-thick-bottom-white px_625 py1 md:px1_875 md:py1_5">
+    <span class="dot-lg mr_25"></span>
+    <span>{{ product.type }}</span>
+    <span class="ProductInfoBar__tags">
+      {% for tag in product.tags %}
+        <span class="ml_625 radius-xs border-white p_25">{{ tag }}</span>
+      {% endfor %}
+    </span>
+  </span>
+  <div class="col-12 md:col-5 flex flex-row justify-start md:justify-end px_625 py1 md:px1_875 md:py1_5 color-white sans-md uppercase">
+    <span class="md:none">{{ product.price | money_without_trailing_zeros }}</span>
+    <span class="md:none mx_25">-</span>
+    <form class=" action="/cart/add" method="post" enctype="multipart/form-data" id="AddToCartForm">
+      <button class="sans-md uppercase bg-color-transparent color-white" type="submit" name="add" id="AddToCart">Add to cart</button>
+    </form>
+  </div>
+  
+</div>

--- a/theme/snippets/product-info-bar.liquid
+++ b/theme/snippets/product-info-bar.liquid
@@ -17,5 +17,4 @@
       <button class="sans-md uppercase bg-color-transparent color-white" type="submit" name="add" id="AddToCart">Add to cart</button>
     </form>
   </div>
-  
 </div>

--- a/theme/styles/_snippets.scss
+++ b/theme/styles/_snippets.scss
@@ -6,3 +6,5 @@
 @import 'snippets/nav';
 @import 'snippets/knowledge-area-header.scss';
 @import 'snippets/knowledge-area-markdown.scss';
+@import 'snippets/markdown.scss';
+@import 'snippets/product-info-bar.scss';

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -24,8 +24,36 @@
   border: 1px solid color('white');
 }
 
+.border-thick-top-white {
+  border-top: 2px solid color('white');
+}
+
+.border-thick-bottom-white {
+  border-bottom: 2px solid color('white');
+}
+
+.border-black {
+  border: 1px solid color('black');
+}
+
+.border-thick-black {
+  border: 2px solid color('black');
+}
+
 .border-top-black {
   border-top: 1px solid color('black');
+}
+
+.border-left-black {
+  border-left: 1px solid color('black');
+}
+
+.border-right-black {
+  border-right: 1px solid color('black');
+}
+
+.border-bottom-black {
+  border-bottom: 1px solid color('black');
 }
 
 .border-thick-top-black {
@@ -40,7 +68,8 @@
   border-bottom: 2px solid color('black');
 }
 
-.dot {
+.dot-sm,
+%dot-sm {
   height: 0.8125rem;
   width: 0.8125rem;
   background-color: color('white');
@@ -48,24 +77,16 @@
   display: inline-block;
 }
 
-.border-black {
-  border: 1px solid color('black');
-}
+.dot-lg {
+  @extend %dot-sm;
 
-.border-thick-black {
-  border: 2px solid color('black');
-}
-
-.border-left-black {
-  border-left: 1px solid color('black');
-}
-
-.border-right-black {
-  border-right: 1px solid color('black');
-}
-
-.border-bottom-black {
-  border-bottom: 1px solid color('black');
+  @include media('lg-up') {
+    height: 1.75rem;
+    width: 1.75rem;
+    background-color: color('white');
+    border-radius: 50%;
+    display: inline-block;
+  }
 }
 
 //* Product Grid */

--- a/theme/styles/snippets/footer.scss
+++ b/theme/styles/snippets/footer.scss
@@ -10,7 +10,7 @@
     font-size: 2.5rem;
     line-height: 2.625rem;
 
-    @include media('md-up') {
+    @include media('lg-up') {
       font-size: 4.0625rem;
       line-height: 3.65625rem;
     }

--- a/theme/styles/snippets/markdown.scss
+++ b/theme/styles/snippets/markdown.scss
@@ -1,3 +1,5 @@
+//Change hover link styling when designs are added.
+
 .Markdown {
   padding-bottom: 3.125rem;
     
@@ -23,6 +25,17 @@
       font-size: 2.5rem;
       line-height: 2.625rem;
     }
+
+    strong {
+      font-weight: 700;
+    }
+
+    a {
+      @extend %transition-shorter;
+      &:hover {
+        color: lighten(color('black'), 25%);
+      }
+    }
   }
 
   ul,
@@ -47,6 +60,13 @@
     display: block;
     overflow-x: auto;
     white-space: nowrap;
+
+    a {
+      @extend %transition-shorter;
+      &:hover {
+        color: lighten(color('black'), 25%);
+      }
+    }
 
     tbody {
       display: table;

--- a/theme/styles/snippets/markdown.scss
+++ b/theme/styles/snippets/markdown.scss
@@ -1,0 +1,50 @@
+.Markdown {
+  padding-bottom: 3.125rem;
+    
+  @include media ('lg-up') {
+    padding-bottom: 12.5rem;
+  }
+
+  h1, h2, h3, p, ul, ol {
+    font-family: $itc-garamond;
+  }
+
+  h2 {
+    padding-bottom: 2.5rem;
+    text-transform: uppercase;
+    @extend %serif-xl;
+  }
+
+  p {
+    padding-bottom: 1.5rem;
+  }
+  
+  ul, ol, p {
+    @extend %serif-sm;
+    
+    @include media('lg-up') {
+      font-size: 2.5rem;
+      line-height: 2.625rem;
+    }
+  }
+
+  ul,
+  ol {
+    list-style-position: inside;
+  }
+
+  ul {
+    list-style-type: none;
+
+    
+    li {
+      &::before {
+        content: "-";
+        margin-right: 0.625rem;
+      }
+    }
+  }
+
+  &--style-black-bg {
+  }
+}

--- a/theme/styles/snippets/markdown.scss
+++ b/theme/styles/snippets/markdown.scss
@@ -10,18 +10,15 @@
   }
 
   h2 {
-    padding-bottom: 2.5rem;
+    padding-bottom: 3.125rem;
     text-transform: uppercase;
     @extend %serif-xl;
   }
 
-  p {
-    padding-bottom: 1.5rem;
-  }
-  
   ul, ol, p {
     @extend %serif-sm;
-    
+    padding-bottom: 2.875rem;
+
     @include media('lg-up') {
       font-size: 2.5rem;
       line-height: 2.625rem;
@@ -45,6 +42,53 @@
     }
   }
 
+  table { 
+    border-collapse: collapse; 
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+
+    tbody {
+      display: table;
+      width: 100%;
+    }
+
+    tr {
+      &:first-of-type {
+        border-top: 1px solid color('black');
+      }
+
+      border-bottom: 1px solid color('black'); 
+    }
+
+    td { 
+      padding: 0.75rem 0;
+
+      @include media('md-up') {
+        padding: 1.25rem 0;
+      }   
+    }
+
+    td:first-of-type {
+      font-family: $itc-garamond;
+      @extend %serif-lg;
+    }
+
+    td:nth-of-type(2) {
+      font-family: $gt-zirkon;
+      @extend %sans-sm;
+      padding-left: 2rem;
+    }
+  }
+
   &--style-black-bg {
+    tr {
+      &:first-of-type {
+        border-top: 1px solid color('white')!important;
+      }
+
+      border-bottom: 1px solid color('white')!important; 
+    }
+
   }
 }

--- a/theme/styles/snippets/product-info-bar.scss
+++ b/theme/styles/snippets/product-info-bar.scss
@@ -1,0 +1,7 @@
+.ProductInfoBar {
+  &__product-details {
+    @include media('md-up') {
+      border-bottom: 0;
+    }
+  }
+}

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -2,43 +2,28 @@
 {% assign featured_image = current_variant.featured_image | default: product.featured_image %}
 {% assign related_products_heading = product.metafields.accentuate.related_products_heading %}
 {% assign related_products_handles = product.metafields.accentuate.related_products | split: '|' %}
+{% assign product_content = product.metafields.accentuate.product_content %}
 
 <div class="Product pt_625 bg-color-black">
   <div class="site-padding-x">
     <h1 class="uppercase serif-xl color-white">{{ product.title }}</h1>
     <p class="uppercase sans-sm color-white">{{ product.vendor }}</p>
   </div>
+
   <img src="{{ featured_image | img_url: 'large' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg">
   {% for image in product.images %}
     <a href="{{ image.src | img_url: 'large' }}">
       <img src="{{ image.src | img_url: 'compact' }}" alt="{{ image.alt | escape }}">
     </a>
   {% endfor %}
-  <form action="/cart/add" method="post" enctype="multipart/form-data" id="AddToCartForm">
-    <select name="id" id="productSelect">
-      {% for variant in product.variants %}
-        {% if variant.available %}
-          <option value="{{ variant.id }}">
-            {{ variant.title }} - {{ variant.price | money_with_currency }}
-          </option>
-        {% else %}
-          <option disabled="disabled">
-            {{ variant.title }} - sold out
-          </option>
-        {% endif %}
-      {% endfor %}
-    </select>
-    {{ current_variant.price | money }}
-    <label for="Quantity">quantity</label>
-    <input type="number" id="Quantity" name="quantity" value="1" min="1">
-    <button type="submit" name="add" id="AddToCart">Add to cart</button>
-  </form>
-  <div>{{ product.description }}</div>
+
+  {% render 'product-info-bar' product: product %}
+
+  {% render 'markdown' variant: 'black-bg' classes: 'site-padding-x py1_25' markdown: product_content.html %}
 
   {% if related_products_heading %}
     <div class="site-padding-x uppercase color-white serif-xl pb2_5">{{ related_products_heading }}</div>
   {% endif %}
-
   <div class="grid grid--style-padding-x-0 bg-color-white pt_125">
     {% for related_products_handle in related_products_handles %}
       {% render 'product-grid-item', current_product: all_products[related_products_handle] %}  

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -2,7 +2,7 @@
 {% assign featured_image = current_variant.featured_image | default: product.featured_image %}
 {% assign related_products_heading = product.metafields.accentuate.related_products_heading %}
 {% assign related_products_handles = product.metafields.accentuate.related_products | split: '|' %}
-{% assign product_content = product.metafields.accentuate.product_content %}
+{% assign product_description = product.metafields.accentuate.product_description %}
 
 <div class="Product pt_625 bg-color-black">
   <div class="site-padding-x">
@@ -19,7 +19,7 @@
 
   {% render 'product-info-bar' product: product %}
 
-  {% render 'markdown' variant: 'black-bg' classes: 'site-padding-x py1_25' markdown: product_content.html %}
+  {% render 'markdown' variant: 'black-bg' classes: 'site-padding-x py1_25' markdown: product_description.html %}
 
   {% if related_products_heading %}
     <div class="site-padding-x uppercase color-white serif-xl pb2_5">{{ related_products_heading }}</div>


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- Adds Product Description Markdown styling 
- Adds Accentuate field: `product_description` (markdown) 
- Adjust `Footer` button media query
- Adds styling of the `ProductInfoBar`. Add to cart functionality will be in another PR. I'm not sure how add to cart works yet, and wanted to get some styling in there in the meantime. Note: Right now "Type Design" is a tag coming from Shopify. This will change in the future when we start to use Shopify Bookings. 

**NOTE: There were a lot of features cut for the MVP to be able to launch faster. The biggest features cut were Knowledge Areas, the Menu Filter for Offerings, and on Product Pages (what this PR covers) we are using markdown only for the product description. Product pages don't have a menu dropdown either.** @sepowitz @limsohee1002 

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
Closes #18 

### How Has This Been Tested?
https://5qwxtf6wyicqmto0-52674822324.shopifypreview.com
pw: nunu
<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->
Designs:
![image](https://user-images.githubusercontent.com/43737723/108890401-25f08100-75d3-11eb-9228-9a938c0837a8.png)
![image](https://user-images.githubusercontent.com/43737723/108890415-2b4dcb80-75d3-11eb-9494-59d244757266.png)

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
- Add to Cart functionality (only styling was added here as a placeholder until I work on Add to Cart)