### PR TITLE
Drawer Cart styling Pt. 1

### DIFF
--- a/theme/locales/en.default.json
+++ b/theme/locales/en.default.json
@@ -61,6 +61,12 @@
         }
       }
     },
+    "cart": {
+      "checkout_button": {
+        "aria_label": "Check out your cart.",
+        "text": "Check out"
+      }
+    },
     "footer": {
       "social_links": {
         "newsletter_link": {

--- a/theme/locales/en.default.json
+++ b/theme/locales/en.default.json
@@ -64,7 +64,13 @@
     "cart": {
       "checkout_button": {
         "aria_label": "Check out your cart.",
-        "text": "Check out"
+        "text": "Check out",
+        "name": "checkout"
+      },
+      "remove_button": {
+        "aria_label": "Remove item from cart",
+        "text": "Remove",
+        "name": "checkout"
       }
     },
     "footer": {

--- a/theme/snippets/cart-item.liquid
+++ b/theme/snippets/cart-item.liquid
@@ -1,0 +1,15 @@
+<a class="CartItem bg-color-black color-white text-decoration-none hover--style-rounded-border relative p_625 mb_125" href="{{ item.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
+  <div class="CartItem__inner-container bg-color-black h100">
+    <div class="flex justify-between">
+      <span class="CartItem__title serif-xs uppercase">{{item.title}}</span>
+      <span class="CartItem__price serif-xs uppercase">{{item.price | money_without_trailing_zeros }}</span>
+    </div>
+    <span class="CartItem__vendor sans-xs">{{item.vendor}}</span>
+    <div class="CartItem__image-container flex items-center justify-center absolute t0 r0 h100 w100">
+      <img class="CartItem__image w100 h100 fit-contain xs:py1" src={{ item | img_url: 'medium' }}" alt="{{ item.title | escape }}">
+    </div>
+    <div class="CartItem__details absolute r0 b0 p_625 w100">
+      <span class="sans-xs uppercase">Remove</span>
+    </div>
+  </div>
+</a>

--- a/theme/snippets/cart-item.liquid
+++ b/theme/snippets/cart-item.liquid
@@ -1,4 +1,4 @@
-<a class="CartItem bg-color-black color-white text-decoration-none hover--style-rounded-border relative p_625 mb_125" href="{{ item.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
+<div class="CartItem bg-color-black color-white relative p_625 mb_125">
   <div class="CartItem__inner-container bg-color-black h100">
     <div class="flex justify-between">
       <span class="CartItem__title serif-xs uppercase">{{ item.title }}</span>
@@ -12,4 +12,4 @@
       <button aria-label={{ 'snippets.cart.remove_button.aria_label' | t }} class="button--style-no-style sans-xs color-white uppercase">{{ 'snippets.cart.remove_button.text' | t }} </button>
     </div>
   </div>
-</a>
+</div>

--- a/theme/snippets/cart-item.liquid
+++ b/theme/snippets/cart-item.liquid
@@ -1,15 +1,15 @@
 <a class="CartItem bg-color-black color-white text-decoration-none hover--style-rounded-border relative p_625 mb_125" href="{{ item.url }}" aria-label="{{ 'snippets.product_grid_item.product_btn.aria_label' | t }}" >
   <div class="CartItem__inner-container bg-color-black h100">
     <div class="flex justify-between">
-      <span class="CartItem__title serif-xs uppercase">{{item.title}}</span>
-      <span class="CartItem__price serif-xs uppercase">{{item.price | money_without_trailing_zeros }}</span>
+      <span class="CartItem__title serif-xs uppercase">{{ item.title }}</span>
+      <span class="CartItem__price serif-xs uppercase">{{ item.price | money_without_trailing_zeros }}</span>
     </div>
-    <span class="CartItem__vendor sans-xs">{{item.vendor}}</span>
+    <span class="CartItem__vendor sans-xs">{{ item.vendor }}</span>
     <div class="CartItem__image-container flex items-center justify-center absolute t0 r0 h100 w100">
       <img class="CartItem__image w100 h100 fit-contain xs:py1" src={{ item | img_url: 'medium' }}" alt="{{ item.title | escape }}">
     </div>
     <div class="CartItem__details absolute r0 b0 p_625 w100">
-      <span class="sans-xs uppercase">Remove</span>
+      <button aria-label={{ 'snippets.cart.remove_button.aria_label' | t }} class="button--style-no-style sans-xs color-white uppercase">{{ 'snippets.cart.remove_button.text' | t }} </button>
     </div>
   </div>
 </a>

--- a/theme/styles/_reset.scss
+++ b/theme/styles/_reset.scss
@@ -106,9 +106,10 @@ section {
   box-sizing: border-box;
 }
 
-a {
+a, button {
   color: currentColor;
   text-decoration: none;
+  cursor: pointer;
 }
 
 button {

--- a/theme/styles/_snippets.scss
+++ b/theme/styles/_snippets.scss
@@ -9,3 +9,4 @@
 @import 'snippets/markdown.scss';
 @import 'snippets/product-info-bar.scss';
 @import 'snippets/product-images-slider.scss';
+@import 'snippets/cart-item.scss';

--- a/theme/styles/buttons.scss
+++ b/theme/styles/buttons.scss
@@ -31,6 +31,7 @@
 .button--style-no-style {
   color: color('inherit');
   text-decoration: none;
+  background-color: transparent;
 }
 
 .hover--style-rounded-border {

--- a/theme/styles/snippets/cart-item.scss
+++ b/theme/styles/snippets/cart-item.scss
@@ -1,0 +1,39 @@
+.CartItem {
+  display: grid;
+
+  //Aspect ratio 
+  &::before {
+    content: "";
+    display: block;
+    height: 0;
+    width: 0;
+    padding-bottom: calc(480/499 * 100%);
+    grid-area: 1 / 1 / 2 / 2;
+  }
+
+  &__inner-container {
+    grid-area: 1 / 1 / 2 / 2;
+    width: 100%
+  }
+
+  &__image {
+    width: 60%;
+    max-height: 13rem;
+
+    @include media('xs-up') {
+      max-height: 22rem;
+    }
+
+    @include media('md-up') {
+      max-height: 11rem;
+    }
+
+    @include media('lg-up') {
+      max-height: 14rem;
+    }
+
+    @include media('xl-up') {
+      max-height: 17rem;
+    }
+  }
+}

--- a/theme/styles/templates.scss
+++ b/theme/styles/templates.scss
@@ -2,3 +2,4 @@
 @import 'templates/news';
 @import 'templates/knowledge-area';
 @import 'templates/product';
+@import 'templates/cart';

--- a/theme/styles/templates/cart.scss
+++ b/theme/styles/templates/cart.scss
@@ -1,0 +1,8 @@
+.Cart {
+  &__checkout-container {
+    margin-top: -0.125rem;
+    font-size: 2.5rem;
+    line-height: 2.625rem;
+    font-family: $itc-garamond;
+  }
+}

--- a/theme/templates/cart.liquid
+++ b/theme/templates/cart.liquid
@@ -6,7 +6,7 @@
     {% endfor %}
       <div class="Cart__checkout-container border-thick-black serif flex justify-between p_625">
         <p>{{ cart.total_price | money }}</p>
-        <button class="Cart__checkout-container button--style-no-style serif uppercase" type="submit" name="checkout">Checkout</button>
+        <button aria-label={{ 'snippets.cart.checkout_button.aria_label' | t }} class="Cart__checkout-container button--style-no-style serif uppercase" type="submit" name="checkout">{{ 'snippets.cart.checkout_button.text' | t }} </button>
       </div>
     </form>
   {% else %}

--- a/theme/templates/cart.liquid
+++ b/theme/templates/cart.liquid
@@ -1,43 +1,11 @@
 {% if cart.item_count > 0 %}
-  <h1>cart</h1>
   <form action="/cart" method="post" novalidate>
-    <table>
-      <thead>
-        <th colspan="2">Prod</th>
-        <th>Price</th>
-        <th>Qty</th>
-        <th>total</th>
-      </thead>
-      <tbody>
-        {% for item in cart.items %}
-          <tr>
-            <td>
-              <a href="{{ item.url | within: collections.all }}">
-                <img src="{{ item | img_url: 'medium' }}" alt="{{ item.title | escape }}">
-              </a>
-            </td>
-            <td>
-              <a href="{{ item.url }}">{{ item.product.title }}</a>
-              {{ item.variant.title }}
-              <a href="/cart/change?line={{ forloop.index }}&amp;quantity=0">remove</a>
-            </td>
-            <td>{{ item.price | money }}</td>
-            <td>
-              <input type="number" name="updates[]" id="updates_{{ item.key }}" value="{{ item.quantity }}" min="0">
-            </td>
-            <td>
-              {% if item.original_line_price != item.line_price %}{{ item.original_line_price | money }}{% endif %}
-              {{ item.line_price | money }}
-              {% for discount in item.discounts %}{{ discount.title }}{% endfor %}
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    <div>
-      <p>sub total : {{ cart.total_price | money }}</p>
-      <button type="submit" name="update">Update</button>
-      <button type="submit" name="checkout">Checkout</button>
+    {% for item in cart.items %}
+      {% render 'cart-item', item: item %}  
+  {% endfor %}
+    <div class="Cart__checkout-container border-thick-black serif flex justify-between p_625">
+      <p>{{ cart.total_price | money }}</p>
+      <button class="Cart__checkout-container button--style-no-style serif uppercase" type="submit" name="checkout">Checkout</button>
     </div>
   </form>
 {% else %}

--- a/theme/templates/cart.liquid
+++ b/theme/templates/cart.liquid
@@ -1,14 +1,15 @@
-{% if cart.item_count > 0 %}
-  <form action="/cart" method="post" novalidate>
-    {% for item in cart.items %}
-      {% render 'cart-item', item: item %}  
-  {% endfor %}
-    <div class="Cart__checkout-container border-thick-black serif flex justify-between p_625">
-      <p>{{ cart.total_price | money }}</p>
-      <button class="Cart__checkout-container button--style-no-style serif uppercase" type="submit" name="checkout">Checkout</button>
-    </div>
-  </form>
-{% else %}
-  <h2>cart</h2>
-  Cart is empty
-{% endif %}
+<div class="Cart px_125">
+  {% if cart.item_count > 0 %}
+    <form action="/cart" method="post" novalidate>
+      {% for item in cart.items %}
+        {% render 'cart-item', item: item %}  
+    {% endfor %}
+      <div class="Cart__checkout-container border-thick-black serif flex justify-between p_625">
+        <p>{{ cart.total_price | money }}</p>
+        <button class="Cart__checkout-container button--style-no-style serif uppercase" type="submit" name="checkout">Checkout</button>
+      </div>
+    </form>
+  {% else %}
+    Cart is empty
+  {% endif %}
+</div>

--- a/theme/templates/cart.liquid
+++ b/theme/templates/cart.liquid
@@ -6,7 +6,7 @@
     {% endfor %}
       <div class="Cart__checkout-container border-thick-black serif flex justify-between p_625">
         <p>{{ cart.total_price | money }}</p>
-        <button aria-label={{ 'snippets.cart.checkout_button.aria_label' | t }} class="Cart__checkout-container button--style-no-style serif uppercase" type="submit" name="checkout">{{ 'snippets.cart.checkout_button.text' | t }} </button>
+        <button to="TO-DO" aria-label={{ 'snippets.cart.checkout_button.aria_label' | t }} class="Cart__checkout-container button--style-no-style serif uppercase" type="submit" name={{ 'snippets.cart.checkout_button.name' | t }}>{{ 'snippets.cart.checkout_button.text' | t }} </button>
       </div>
     </form>
   {% else %}

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -4,6 +4,27 @@
 {% assign related_products_handles = product.metafields.accentuate.related_products | split: '|' %}
 {% assign product_description = product.metafields.accentuate.product_description %}
 
+{% comment %} TO-DO: This cart is for testing purposes only, until the Add to Cart functionality has been implemented.) {% endcomment %}
+<form action="/cart/add" method="post" enctype="multipart/form-data" id="AddToCartForm">
+  <select name="id" id="productSelect">
+    {% for variant in product.variants %}
+      {% if variant.available %}
+        <option value="{{ variant.id }}">
+          {{ variant.title }} - {{ variant.price | money_with_currency }}
+        </option>
+      {% else %}
+        <option disabled="disabled">
+          {{ variant.title }} - sold out
+        </option>
+      {% endif %}
+    {% endfor %}
+  </select>
+  {{ current_variant.price | money }}
+  <label for="Quantity">quantity</label>
+  <input type="number" id="Quantity" name="quantity" value="1" min="1">
+  <button type="submit" name="add" id="AddToCart">Add to cart</button>
+</form>
+
 <div class="Product pt_625 bg-color-black">
   <div class="site-padding-x">
     <h1 class="uppercase serif-xl color-white">{{ product.title }}</h1>


### PR DESCRIPTION
### Description
- Adds styling of `DrawerCart`
- This is still viewable at `/cart`, the way Shopify builds it. In Pt. 2 I will implement the actual "drawer" functionality and use the Cart object instead of linking to `/cart`.

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] New feature
- [x] Update to an existing feature

### Motivation for PR
#66 
<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?
https://jm0pcqdocv8k913p-52674822324.shopifypreview.com
pw: nunu

Click on `Cart`
**Note: It takes the full width of the page but the styling should be the same when it is made the size of the Drawer Cart in pt 2. Will adjust styling if needed.**

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->
![image](https://user-images.githubusercontent.com/43737723/109562569-2e016280-7aa4-11eb-8730-85f6355ca4df.png)
Empty cart: 
![Screen Shot 2021-03-02 at 6 48 21 PM](https://user-images.githubusercontent.com/43737723/109735161-ea802480-7b87-11eb-9b06-c65fa5beaa36.png)

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
- In Pt. 2 I will implement the actual "drawer" functionality and use the Cart object instead of linking to `/cart`.
