### PR TITLE
Update Nav Styling

### DIFF
--- a/theme/snippets/nav.liquid
+++ b/theme/snippets/nav.liquid
@@ -1,9 +1,9 @@
 <nav class="Nav none md:flex border-bottom-black text-nav uppercase sans-serif py_5 px_625 md:px1_25 flex justify-between">
   <div>
-    <a class="{% if request.path == '/' %} Nav__button--active" {% endif %}" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
+    <a class="p_25 md:px_25 md:py0 {% if request.path == '/' %} Nav__button--active" {% endif %}" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
     <span>{{ 'snippets.nav.hyphen' | t }}</span>
     {% for link in linklists.main-menu.links %}
-      <a class="{% if request.path == link.url %} Nav__button--active {% endif %}" href="{{ link.url }}">{{ link.title }}</a>{% if forloop.last == false %},{% endif %}
+      <a class="Nav__button p_25 md:px_25 md:py0 mr4_375 {% if request.path == link.url %} Nav__button--active {% endif %}" href="{{ link.url }}">{{ link.title }}</a>
     {% endfor %}  
   </div>
   {% render 'nav-cart' %}
@@ -12,8 +12,8 @@
 <nav data-activatable class="Nav MobileNav md:none border-bottom-black text-nav uppercase sans-serif py_5 px_625 md:px1_25 flex flex-col col-12">
   <div class="flex justify-between mb_25">
     <span class="flex items-center justify-center">
-      <a href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
-      <button data-activatable-activate-trigger class="bg-color-transparent"><img src="{{ 'menu-icon.svg' | asset_url }}" alt="{{ 'snippets.nav.menu_icon.alt' | t }}" class="MobileNav__icon" /></button>
+      <a class="pr_5 md:pr0" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
+      <button data-activatable-activate-trigger class="MobileNav__icon transition-long bg-color-transparent"><img class="w100 h100 fit-contain" src="{{ 'menu-icon.svg' | asset_url }}" alt="{{ 'snippets.nav.menu_icon.alt' | t }}" /></button>
     </span>
     {% render 'nav-cart' %}
   </div>
@@ -21,16 +21,18 @@
   <div id="nav-mobile-menu" class="MobileNav__menu transition-shorter bg-color-white vh100 vw100 fixed t0 r0 flex flex-col py_5 px_625 md:px1_25 z-nav">
     <div class="flex justify-between mb_25">
       <span class="flex items-center justify-center">
-        <a href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
-        <button data-activatable-deactivate-trigger class="bg-color-transparent"><img src="{{ 'close-icon.svg' | asset_url }}" alt="{{ 'snippets.nav.close_icon.alt' | t }}" class="MobileNav__icon" /></button>
+        <a class="pr_5 md:pr0" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
+        <button data-activatable-deactivate-trigger class="MobileNav__icon MobileNav__close-icon transition opacity-0 events-none bg-color-transparent"><img class="w100 h100 fit-contain" src="{{ 'close-icon.svg' | asset_url }}" alt="{{ 'snippets.nav.close_icon.alt' | t }}" /></button>
       </span>
       {% render 'nav-cart' %}
     </div>
-    <a class="uppercase py1_875" href="/" aria-label="{{ 'snippets.nav.links.home_link.aria_label' | t }}">{{ 'snippets.nav.links.home_link.text' | t }}</a>
-    <a class="uppercase pb1_875" href="/pages/about" aria-label="{{ 'snippets.nav.links.about_link.aria_label' | t }}">{{ 'snippets.nav.links.about_link.text' | t }}</a>
-    <a class="uppercase" href="/pages/news" aria-label="{{ 'snippets.nav.links.news_link.aria_label' | t }}">{{ 'snippets.nav.links.news_link.text' | t }}</a>
+    <div class="MobileNav__menu-links flex flex-col">
+      <a class="opacity-0 events-none hover-lighten-black uppercase py1_875" href="/" aria-label="{{ 'snippets.nav.links.home_link.aria_label' | t }}">{{ 'snippets.nav.links.home_link.text' | t }}</a>
+      <a class="opacity-0 events-none hover-lighten-black uppercase pb1_875" href="/pages/about" aria-label="{{ 'snippets.nav.links.about_link.aria_label' | t }}">{{ 'snippets.nav.links.about_link.text' | t }}</a>
+      <a class="opacity-0 events-none hover-lighten-black uppercase" href="/pages/news" aria-label="{{ 'snippets.nav.links.news_link.aria_label' | t }}">{{ 'snippets.nav.links.news_link.text' | t }}</a>
+    </div>
   </div>
 
-  <a class="{% if request.path == "/collections/all" %} Nav__button--active {% endif %}" href="/collections/all" aria-label="{{ 'snippets.nav.links.shop_link.aria_label' | t }}">{{ 'snippets.nav.links.shop_link.text' | t }}</a>
+  <a class="p_25 md:px_25 md:py0 {% if request.path == "/collections/offerings-collection" %} Nav__button--active {% endif %}" href="/collections/offerings-collection" aria-label="{{ 'snippets.nav.links.shop_link.aria_label' | t }}">{{ 'snippets.nav.links.shop_link.text' | t }}</a>
   
 </nav>

--- a/theme/snippets/nav.liquid
+++ b/theme/snippets/nav.liquid
@@ -1,9 +1,9 @@
-<nav class="Nav none md:flex border-bottom-black text-nav uppercase sans-serif py_5 px_625 md:px1_25 flex justify-between">
-  <div>
-    <a class="p_25 md:px_25 md:py0 {% if request.path == '/' %} Nav__button--active" {% endif %}" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
-    <span>{{ 'snippets.nav.hyphen' | t }}</span>
+<nav class="Nav none md:flex border-bottom-black uppercase sans-serif py_5 px_625 md:px_5 text-nav flex items-center justify-between">
+  <div class="flex flex-row items-center justify-center">
+    <a class="Nav__button radius-xs nav-button-padding {% if request.path == '/' %} Nav__button--active" {% endif %}" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
+    <span class="mx_75">{{ 'snippets.nav.hyphen' | t }}</span>
     {% for link in linklists.main-menu.links %}
-      <a class="Nav__button p_25 md:px_25 md:py0 mr4_375 {% if request.path == link.url %} Nav__button--active {% endif %}" href="{{ link.url }}">{{ link.title }}</a>
+      <a class="Nav__button radius-xs nav-button-padding mr4_375 {% if request.path == link.url %} Nav__button--active {% endif %}" href="{{ link.url }}">{{ link.title }}</a>
     {% endfor %}  
   </div>
   {% render 'nav-cart' %}
@@ -12,7 +12,7 @@
 <nav data-activatable class="Nav MobileNav md:none border-bottom-black text-nav uppercase sans-serif py_5 px_625 md:px1_25 flex flex-col col-12">
   <div class="flex justify-between mb_25">
     <span class="flex items-center justify-center">
-      <a class="pr_5 md:pr0" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
+      <a class="Nav__button radius-xs nav-button-padding mr_5 md:mr0" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
       <button data-activatable-activate-trigger class="MobileNav__icon transition-long bg-color-transparent"><img class="w100 h100 fit-contain" src="{{ 'menu-icon.svg' | asset_url }}" alt="{{ 'snippets.nav.menu_icon.alt' | t }}" /></button>
     </span>
     {% render 'nav-cart' %}
@@ -21,7 +21,7 @@
   <div id="nav-mobile-menu" class="MobileNav__menu transition-shorter bg-color-white vh100 vw100 fixed t0 r0 flex flex-col py_5 px_625 md:px1_25 z-nav">
     <div class="flex justify-between mb_25">
       <span class="flex items-center justify-center">
-        <a class="pr_5 md:pr0" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
+        <a class="Nav__button radius-xs nav-button-padding mr_5 md:mr0" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}">{{ 'snippets.nav.links.index_link.text' | t }}</a>
         <button data-activatable-deactivate-trigger class="MobileNav__icon MobileNav__close-icon transition opacity-0 events-none bg-color-transparent"><img class="w100 h100 fit-contain" src="{{ 'close-icon.svg' | asset_url }}" alt="{{ 'snippets.nav.close_icon.alt' | t }}" /></button>
       </span>
       {% render 'nav-cart' %}
@@ -33,6 +33,6 @@
     </div>
   </div>
 
-  <a class="p_25 md:px_25 md:py0 {% if request.path == "/collections/offerings-collection" %} Nav__button--active {% endif %}" href="/collections/offerings-collection" aria-label="{{ 'snippets.nav.links.shop_link.aria_label' | t }}">{{ 'snippets.nav.links.shop_link.text' | t }}</a>
+  <a class="Nav__button radius-xs nav-button-padding {% if request.path == "/collections/offerings-collection" %} Nav__button--active {% endif %}" href="/collections/offerings-collection" aria-label="{{ 'snippets.nav.links.shop_link.aria_label' | t }}">{{ 'snippets.nav.links.shop_link.text' | t }}</a>
   
 </nav>

--- a/theme/styles/_config.scss
+++ b/theme/styles/_config.scss
@@ -6,7 +6,7 @@ $colors: (
 );
 
 $spacing-units: 0rem, 0.125rem, 0.25rem, 0.5rem, 0.625rem, 0.75rem, 1rem, 1.25rem, 1.5rem, 1.75rem, 1.875rem, 2rem,
-  2.5rem, 2.75rem, 3rem, 3.5rem, 3.75rem, 4rem, 5rem, 6rem, 7rem, 8rem, 10rem;
+  2.5rem, 2.75rem, 3rem, 3.5rem, 3.75rem, 4rem, 4.375rem, 5rem, 6rem, 7rem, 8rem, 10rem;
 
 $breakpoints: (
   'xxs': 375px,

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -123,3 +123,11 @@
 .hyphens {
   hyphens: auto;
 }
+
+.nav-button-padding {
+  padding: 0.1875rem;
+
+  @include media('md-up') {
+    padding: 0.15rem 0.25rem;
+  }
+}

--- a/theme/styles/global.scss
+++ b/theme/styles/global.scss
@@ -125,9 +125,9 @@
 }
 
 .nav-button-padding {
-  padding: 0.1875rem;
+  padding: 0.1875rem 0.1875rem 0.05rem 0.1875rem;
 
   @include media('md-up') {
-    padding: 0.15rem 0.25rem;
+    padding: 0.25rem 0.25rem 0.1rem 0.25rem;
   }
 }

--- a/theme/styles/settings/_transitions.scss
+++ b/theme/styles/settings/_transitions.scss
@@ -5,6 +5,7 @@ $transition-duration-medium: 0.4s;
 $transition-duration-long: 1s;
 $transition-cubic-bezier: cubic-bezier(0.15, 0.85, 0.45, 1);
 $transition: $transition-duration-short $transition-cubic-bezier;
+$transition-easing: ease-in-out;
 
 .transition-shortest,
 %transition-shortest {
@@ -32,4 +33,16 @@ $transition: $transition-duration-short $transition-cubic-bezier;
 
 .transition-long {
   transition: all $transition-duration-long $transition-cubic-bezier;
+}
+
+@keyframes animation-fade-in-down-short {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, -1rem, 0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
 }

--- a/theme/styles/settings/_vars.scss
+++ b/theme/styles/settings/_vars.scss
@@ -10,3 +10,4 @@ $site-padding-x-desktop: 1.25rem;
 $site-padding-x-desktop-double: 2.5rem;
 $vendor-avatar-height-mobile: 1.5rem;
 $vendor-avatar-height-desktop: 2.9375rem;
+$nav-height-desktop-xl: 3.6875rem;

--- a/theme/styles/snippets/nav.scss
+++ b/theme/styles/snippets/nav.scss
@@ -1,20 +1,14 @@
-.Nav {  
+.Nav {
   @include media('xl-up') {
     height: $nav-height-desktop-xl;
   }
 
  &__button  {
   @extend %transition-short; 
-  line-height: 0;
 
-   &:hover, &--active {
+  &:hover, &--active {
     background-color: color('black');
     color: color('white');
-    border-radius: radius('xs');
-
-    @include media('xl-up') {
-      border-radius: radius('sm');
-    }
    }
  }
 }
@@ -58,11 +52,6 @@
       a:nth-child(3) {
         animation: $transition-duration-short cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.2s 1 normal forwards animation-fade-in-down-short;
       }
-  
-      a:nth-child(4) {
-        animation: $transition-duration-short cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.25s 1 normal forwards animation-fade-in-down-short;
-      }
-
     }
   }
 }

--- a/theme/styles/snippets/nav.scss
+++ b/theme/styles/snippets/nav.scss
@@ -1,43 +1,68 @@
-.Nav {
- a {
-   @extend %transition-short; 
+.Nav {  
+  @include media('xl-up') {
+    height: $nav-height-desktop-xl;
+  }
 
-   &:hover {
-    color: lighten(black, 25%);
+ &__button  {
+  @extend %transition-short; 
+  line-height: 0;
+
+   &:hover, &--active {
+    background-color: color('black');
+    color: color('white');
+    border-radius: radius('xs');
+
+    @include media('xl-up') {
+      border-radius: radius('sm');
+    }
    }
  }
-
- &__button--active {
-  background-color: color('black');
-  color: color('white');
-  border-radius: radius('xs');
-  padding: 0.25rem 0.25rem;
-
-  @include media('md-up') {
-    padding: 0 0.25rem;
-  }
-  @include media('xl-up') {
-    border-radius: radius('sm');
-  }
- }
-
 }
 
 .MobileNav {
-  &__icon {
-    padding-left: 0.5625rem;
-    max-height: 1.281875rem;
+  &__icon img {
+    width: 1.8125rem;
+    height: 1.3125rem;
   }
   
   &__menu {
+    @extend .transition;
     opacity: 0;
     pointer-events: none;
   }
 
   &[data-active="true"] {
+    .MobileNav__close-icon {
+      opacity: 1;
+      pointer-events: all;
+    }
+
     .MobileNav__menu {
       opacity: 1;
       pointer-events: all;
+    }
+
+    .MobileNav__menu-links {
+      a {
+        pointer-events: all!important;
+      }
+
+      a:nth-child(1) {
+        animation: $transition-duration-short cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.1s 1 normal forwards animation-fade-in-down-short;
+      }
+  
+      a:nth-child(2) {
+        animation: $transition-duration-short cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.15s 1 normal forwards animation-fade-in-down-short;
+      }
+  
+      a:nth-child(3) {
+        animation: $transition-duration-short cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.2s 1 normal forwards animation-fade-in-down-short;
+      }
+  
+      a:nth-child(4) {
+        animation: $transition-duration-short cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.25s 1 normal forwards animation-fade-in-down-short;
+      }
+
     }
   }
 }


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- Updates Nav styling
- Adds some transitions to the mobile menu
- **NOTE: Icons were cut.**

Behavior: 
- Hover over a main nav link and the link should have a black bg/white font with rounded borders
- An active link should have the same hover styling


### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?
https://e7ao9dyu8xniorpf-52674822324.shopifypreview.com
pw: nunu

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->

### Applicable screenshots:
Designs:
![image](https://user-images.githubusercontent.com/43737723/109733009-e3efae00-7b83-11eb-9b52-2e6e33cb472f.png)
![image](https://user-images.githubusercontent.com/43737723/109733157-2f09c100-7b84-11eb-800b-7d3e9d5da85a.png)


<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
- May need to change transitions when XXIX sees/QAs the nav. 