### PR TITLE
QA: Black flash on image slider

### DIFF
--- a/theme/styles/snippets/product-images-slider.scss
+++ b/theme/styles/snippets/product-images-slider.scss
@@ -21,6 +21,7 @@
     bottom: 0;
     left: 0;
     width: 50%;
+    -webkit-tap-highlight-color: color('transparent');
   }
 
   .splide__arrow--next {
@@ -29,5 +30,37 @@
     bottom: 0;
     left: 50%;
     width: 50%;
+    -webkit-tap-highlight-color: color('transparent');
   }
+}
+
+/**
+  Prevents black flash
+  seen on certain browsers when 
+  changin slides
+
+  See: https://github.com/Splidejs/splide/issues/220
+*/
+.splide__list {
+  margin: 0 !important;
+  padding: 0 !important;
+  height: 100%;
+  display: flex;
+  width: -webkit-max-content;
+  width: max-content;
+  will-change: transform;
+}
+
+.splide__track > .splide__list > .splide__slide {
+  width: 100%;
+  transform: translate3d(0px,0,0);
+  -webkit-transform: translate3d(0px,0,0);
+  -moz-transform: translate3d(0px,0,0);
+  -ms-transform: translate3d(0px,0,0);
+  -o-transform: translate3d(0px,0,0);
+  will-change: inherit;
+}
+  
+.splide__list > .splide__slide:first-child {
+  z-index: 2;
 }


### PR DESCRIPTION
### Description

Removes black flash seen when cycling through slide on the ProductImageSlider

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?

https://zdnveagziu3y2u56-52674822324.shopifypreview.com

- View it on safari (compared to current master on index-space.org)
- View it on mobile browsers

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
