### PR TITLE
QA: Use Dingbats Font when using <strong> styling in Markdown

### DIFF
--- a/theme/snippets/product-info-bar.liquid
+++ b/theme/snippets/product-info-bar.liquid
@@ -46,8 +46,8 @@
     </span>
   </span>
   <div class="ProductInfoBar__add-to-cart-container col-12 md:col-5 flex flex-row justify-start md:justify-end px_625 py1 md:pl0 md:py1_3125 color-white sans-light-md uppercase">
-    <span class="pt_15 md:none">{{ product.price | money_without_trailing_zeros }}</span>
-    <span class="pt_15 md:none mx_25">-</span>
+    <span class="pt_25 md:none">{{ product.price | money_without_trailing_zeros }}</span>
+    <span class="pt_25 md:none mx_25">-</span>
     
     <form data-add-to-cart-form data-product-type={{product_type}} action="/cart/add" method="post" enctype="multipart/form-data" id="AddToCartForm">
       <select class="{% if product.variants.size <= 1 %} none {% endif %}" name="variant" data-variant-selector>

--- a/theme/styles/snippets/markdown.scss
+++ b/theme/styles/snippets/markdown.scss
@@ -6,8 +6,10 @@ $text-max-width: 65rem;
   }
 
   /* Bold class used for Dingbats Font in Home Page Intro */
-  h1 strong {
-    font-family: $logo;
+  h1, h2, h3, h4, h5, h6, p, ol, ul {
+    strong {
+      font-family: $logo;
+    }
   }
 
   h4, h5, h6 {

--- a/theme/styles/snippets/markdown.scss
+++ b/theme/styles/snippets/markdown.scss
@@ -5,6 +5,11 @@ $text-max-width: 65rem;
     font-family: $serif;
   }
 
+  /* Bold class used for Dingbats Font in Home Page Intro */
+  h1 strong {
+    font-family: $logo;
+  }
+
   h4, h5, h6 {
     font-family: $sans-serif;
   }


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- Use Dingbats Font when using `<strong>` styling in Markdown h1 - h6, p, ol, ul
- Also fixes QA issue: Price / product name misalignment
### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://9iafk3303qx338cx-52674822324.shopifypreview.com
(Should see some random test words with dingbats)
### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
