### PR TITLE
Bugfix: Change page transition "load" to "DOMContentLoaded"

### DIFF
--- a/theme/scripts/pageTransition.ts
+++ b/theme/scripts/pageTransition.ts
@@ -9,7 +9,7 @@ export default (function() {
     },
 
     bindEventListeners() {
-      window.addEventListener('load', PageTransition.fadeIn)
+      window.addEventListener('DOMContentLoaded', PageTransition.fadeIn)
     },
 
     fadeIn() {


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- Change page transition "load" to "DOMContentLoaded"

The DOMContentLoaded event fires when the initial HTML document has been completely loaded and parsed, without waiting for stylesheets, images, and subframes to finish loading.

A different event, load, should be used only to detect a fully-loaded page. It is a common mistake to use load where DOMContentLoaded would be more appropriate.

https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
QA ticket: It seems like page loads are blocked for quite some time. Why is that? If we are waiting for all images to load, we should not be doing that as it hurts SEO Page Scores

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://m310sv91bskhkmu0-52674822324.shopifypreview.com

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
