### PR TITLE
QA: Update Product Grid animations and make Product Images Slider images swipeable on mobile

### DIFF
--- a/theme/scripts/productImagesSlider.ts
+++ b/theme/scripts/productImagesSlider.ts
@@ -16,18 +16,13 @@ export default(function() {
 
 		setup(slider: HTMLElement) {
 			new Splide(slider, {
-				classes: {
-					arrows: 'splide__arrows--override',
-					arrow : 'splide__arrow--override',
-				},
 				speed: 800,
 				type: 'loop',
+				arrows: false,
 				pagination: false,
-				arrows: true,
 				focus: 'center',
 				perPage: 1.35,
-				trimSpace: false,
-				drag: true
+				trimSpace: false
 			}).mount();
 		}
 	};

--- a/theme/scripts/productImagesSlider.ts
+++ b/theme/scripts/productImagesSlider.ts
@@ -22,8 +22,8 @@ export default(function() {
 				},
 				speed: 800,
 				type: 'loop',
-				arrows: true,
 				pagination: false,
+				arrows: true,
 				focus: 'center',
 				perPage: 1.35,
 				trimSpace: false

--- a/theme/scripts/productImagesSlider.ts
+++ b/theme/scripts/productImagesSlider.ts
@@ -27,6 +27,7 @@ export default(function() {
 				focus: 'center',
 				perPage: 1.35,
 				trimSpace: false,
+				drag: true
 			}).mount();
 		}
 	};

--- a/theme/scripts/productImagesSlider.ts
+++ b/theme/scripts/productImagesSlider.ts
@@ -16,9 +16,13 @@ export default(function() {
 
 		setup(slider: HTMLElement) {
 			new Splide(slider, {
+				classes: {
+					arrows: 'splide__arrows--override',
+					arrow : 'splide__arrow--override',
+				},
 				speed: 800,
 				type: 'loop',
-				arrows: false,
+				arrows: true,
 				pagination: false,
 				focus: 'center',
 				perPage: 1.35,

--- a/theme/styles/settings/_transitions.scss
+++ b/theme/styles/settings/_transitions.scss
@@ -47,14 +47,12 @@ $transition-easing: ease-in-out;
   }
 }
 
-@keyframes animation-fade-in-up {
+@keyframes animation-fade-in {
   0% {
-    transform: translate3d(0, 1.125rem, 0);
     opacity: 0;
   }
 
   100% {
-    transform: translate3d(0, 0, 0);
     opacity: 1;
   }
 }

--- a/theme/styles/snippets/product-grid-item.scss
+++ b/theme/styles/snippets/product-grid-item.scss
@@ -46,7 +46,7 @@
 
   &[data-fade-in="true"] {
     .ProductGridItem__image {
-      animation: $transition-duration-long cubic-bezier(0.25, 0.46, 0.45, 0.94)1 normal forwards animation-fade-in-up;
+      animation: $transition-duration-long cubic-bezier(0.25, 0.46, 0.45, 0.94)1 normal forwards animation-fade-in;
       pointer-events: all;
     }
   }

--- a/theme/styles/snippets/product-images-slider.scss
+++ b/theme/styles/snippets/product-images-slider.scss
@@ -8,30 +8,6 @@
       max-height: 40rem;
     }
   }
-
-  .splide__arrow--override {
-    position: absolute;
-    z-index: 1;
-    opacity: 0;
-  }
-
-  .splide__arrow--prev {
-    top: 0;
-    right: 50%;
-    bottom: 0;
-    left: 0;
-    width: 50%;
-    -webkit-tap-highlight-color: color('transparent');
-  }
-
-  .splide__arrow--next {
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 50%;
-    width: 50%;
-    -webkit-tap-highlight-color: color('transparent');
-  }
 }
 
 /**

--- a/theme/styles/snippets/product-images-slider.scss
+++ b/theme/styles/snippets/product-images-slider.scss
@@ -13,7 +13,7 @@
     //Hide the arrows on mobile, so the images are swipeable.
     display: none;
 
-    @include media('md-up') {
+    @include media('sm-up') {
       display: block;
       position: absolute;
       z-index: 1;

--- a/theme/styles/snippets/product-images-slider.scss
+++ b/theme/styles/snippets/product-images-slider.scss
@@ -8,6 +8,36 @@
       max-height: 40rem;
     }
   }
+
+  .splide__arrow--override {
+    //Hide the arrows on mobile, so the images are swipeable.
+    display: none;
+
+    @include media('md-up') {
+      display: block;
+      position: absolute;
+      z-index: 1;
+      opacity: 0;
+    }
+  }
+
+  .splide__arrow--prev {
+    top: 0;
+    right: 50%;
+    bottom: 0;
+    left: 0;
+    width: 50%;
+    -webkit-tap-highlight-color: color('transparent');
+  }
+
+  .splide__arrow--next {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 50%;
+    width: 50%;
+    -webkit-tap-highlight-color: color('transparent');
+  }
 }
 
 /**


### PR DESCRIPTION
### Description
- Update product grid animations and add drag to product images slider

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Update to an existing feature

### Motivation for PR
QA tickets: 
I should be able to swipe PDP image galleries on Mobile

IMO: The upward animation when images fade in is "a bit much". Can we just do the opacity fade and lose the up-and-in?
<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://jr2833b9kaw3v10h-52674822324.shopifypreview.com
### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
