### PR TITLE
QA: Hide past news items from Homepage news feed

### DIFF
--- a/theme/snippets/news-feed.liquid
+++ b/theme/snippets/news-feed.liquid
@@ -1,4 +1,5 @@
 {% assign see_more_link_label = shop.metafields.accentuate.news_feed_see_more_link_label %}
+{% assign today = "now" | date: "%Y-%m-%d" %}
 
 <div class="NewsFeed">
   <div class="NewsFeed__inner-container flex flex-col">
@@ -7,7 +8,16 @@
     {% for thumbnail in multi_thumbnails %} 
       {% assign current_thumbnail = thumbnail %}
     {% endfor %}
-    {% render 'news-feed-item', cloudinary_src: current_thumbnail.cloudinary_src, image_alt: current_thumbnail.alt, body: value, cta_label: shop.metafields.accentuate.news_feed_item_cta_label[forloop.index0], link: shop.metafields.accentuate.news_feed_item_link[forloop.index0] %}
+    {% comment %}
+    On the homepage, hide news feed items with happens_at dates in the past. On the news feed page, show all news feed items. 
+    {% endcomment %}
+    {% if request.path == '/' %} 
+      {% if shop.metafields.accentuate.news_feed_item_happens_at[forloop.index0] >= today %}    
+        {% render 'news-feed-item', cloudinary_src: current_thumbnail.cloudinary_src, image_alt: current_thumbnail.alt, body: value, cta_label: shop.metafields.accentuate.news_feed_item_cta_label[forloop.index0], link: shop.metafields.accentuate.news_feed_item_link[forloop.index0] %}
+      {% endif %}
+      {% else %}
+        {% render 'news-feed-item', cloudinary_src: current_thumbnail.cloudinary_src, image_alt: current_thumbnail.alt, body: value, cta_label: shop.metafields.accentuate.news_feed_item_cta_label[forloop.index0], link: shop.metafields.accentuate.news_feed_item_link[forloop.index0] %}
+    {% endif %}
   {% endfor %}
   </div>
   {% if limit %}


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- Homepage news feed will only show news feed items with dates in the future, or equal to today's date.
- News page news feed shows all news feed items.
- Added an Accentuate field `news_feed_happens_at` (date field) so editors will need to add this date when they're creating news feed items.

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->
- [x] Update to an existing feature

### Motivation for PR
QA ticket: Items in the "News Feed" should have a happens_at timestamp that means a past item will not show on the homepage, and only show in a special: "In the Past" section of /news
<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
- By changing the Accentuate field `news_feed_happens_at` dates to past dates and future dates to see if they appear in the homepage news feed.

https://p6k47s04h4xyow0y-52674822324.shopifypreview.com
### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
- TBD: Add design for an "in the past" section on the News page. 