### PR TITLE
Feature/181 show state events courses

### DIFF
--- a/theme/locales/en.default.json
+++ b/theme/locales/en.default.json
@@ -108,7 +108,7 @@
       "upcoming": "Upcoming",
       "past": "Past",
       "sold_out": "Sold out",
-      "registrated_closed": "Registration closed"
+      "registration_closed": "Registration closed"
     },
     "cookie_consent": {
       "alt": "Yellow circle cookie consent pop up",

--- a/theme/locales/en.default.json
+++ b/theme/locales/en.default.json
@@ -104,6 +104,12 @@
         "aria_label": "Navigate to the product page."
       }
     },
+    "product_registration_state": {
+      "upcoming": "Upcoming",
+      "past": "Past",
+      "sold_out": "Sold out",
+      "registrated_closed": "Registration closed"
+    },
     "cookie_consent": {
       "alt": "Yellow circle cookie consent pop up",
       "aria_label": "Cookie Consent pop up"

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -27,7 +27,7 @@
           {% if lowercase_product_type == "course" or lowercase_product_type == "event" %}
             {% render 'product-registration-state' product: current_product, product_type: lowercase_product_type %}
           {% else %}
-            <span class="ProductGridItem__price text-left pl1_5 uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
+            <span class="ProductGridItem__price text-right pl1_5 uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
           {% endif %}
         </div>
         {% render 'product-vendor' product: current_product, display_variant: 'grid-item' %}

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -2,8 +2,8 @@
 
 <!-- Get product type -->
 {% assign current_product_type = "" %}
-{% if current_product.first_available_variant.metafields.bookings != blank %}
-  {% assign current_product_type = current_product.first_available_variant.metafields.bookings.bookable_type %}
+{% if current_product.variants[0].metafields.bookings != blank %}
+  {% assign current_product_type = current_product.variants[0].metafields.bookings.bookable_type %}
 {% else %}
   {% assign current_product_type = current_product.type %}
 {% endif %}
@@ -23,7 +23,12 @@
       <span class="flex flex-col uppercase">
         <div class="flex justify-between">
           <span class="ProductGridItem__title">{{current_product.title}}</span>
-          <span class="ProductGridItem__price uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
+          {% assign lowercase_product_type = current_product_type | downcase %}
+          {% if lowercase_product_type == "course" or lowercase_product_type == "event" %}
+            {% render 'product-registration-state' product: current_product, product_type: lowercase_product_type %}
+          {% else %}
+            <span class="ProductGridItem__price uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
+          {% endif %}
         </div>
         {% render 'product-vendor' product: current_product, display_variant: 'grid-item' %}
       </span>

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -27,7 +27,7 @@
           {% if lowercase_product_type == "course" or lowercase_product_type == "event" %}
             {% render 'product-registration-state' product: current_product, product_type: lowercase_product_type %}
           {% else %}
-            <span class="ProductGridItem__price uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
+            <span class="ProductGridItem__price text-left pl1_5 uppercase">{{current_product.price | money_without_trailing_zeros }}</span>
           {% endif %}
         </div>
         {% render 'product-vendor' product: current_product, display_variant: 'grid-item' %}

--- a/theme/snippets/product-registration-state.liquid
+++ b/theme/snippets/product-registration-state.liquid
@@ -25,4 +25,4 @@
   {% assign registration_state = 'snippets.product_registration_state.sold_out' | t %}
 {% endif %}
 
-<span class="ProductGridItem__price text-left pl1_5 uppercase">{{ registration_state }}</span>
+<span class="ProductGridItem__price text-right pl1_5 uppercase">{{ registration_state }}</span>

--- a/theme/snippets/product-registration-state.liquid
+++ b/theme/snippets/product-registration-state.liquid
@@ -1,0 +1,28 @@
+{% assign registration_state = "UPCOMING" %}
+
+{% if product.price != 0 %}
+  {% assign registration_state = product.price | money_without_trailing_zeros %}
+{% endif %}
+
+{% assign current_variant = product.selected_or_first_available_variant %}
+{% assign bookings_metafields = current_variant.metafields.bookings %}
+{% assign todays_date = 'now' | date: '%s' %}
+
+{% if product_type == "course" %}
+  {% assign sessions_sorted = bookings_metafields.sessions | sort: 'starts_at' %}
+  {% assign starts_at = sessions_sorted.first.starts_at | date: '%s' %}
+  {% assign ends_at = sessions_sorted.last.ends_at | date: '%s' %}
+{% elsif product_type == "event" %}
+  {% assign starts_at = bookings_metafields.starts_at | date: '%s' %}
+  {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
+{% endif %}
+
+{% if todays_date > ends_at %}
+  {% assign registration_state = "PAST" %}
+{% elsif todays_date > starts_at %}
+  {% assign registration_state = "REGISTRATION CLOSED" %}
+{% elsif todays_date < starts_at and current_variant.available != true %}
+  {% assign registration_state = "SOLD OUT" %}
+{% endif %}
+
+<span class="ProductGridItem__price uppercase">{{ registration_state }}</span>

--- a/theme/snippets/product-registration-state.liquid
+++ b/theme/snippets/product-registration-state.liquid
@@ -1,4 +1,4 @@
-{% assign registration_state = "UPCOMING" %}
+{% assign registration_state = 'snippets.product_registration_state.upcoming' | t %}
 
 {% if product.price != 0 %}
   {% assign registration_state = product.price | money_without_trailing_zeros %}
@@ -18,11 +18,11 @@
 {% endif %}
 
 {% if todays_date > ends_at %}
-  {% assign registration_state = "PAST" %}
+  {% assign registration_state = 'snippets.product_registration_state.past' | t %}
 {% elsif todays_date > starts_at %}
-  {% assign registration_state = "REGISTRATION CLOSED" %}
+  {% assign registration_state = 'snippets.product_registration_state.registration_closed' | t %}
 {% elsif todays_date < starts_at and current_variant.available != true %}
-  {% assign registration_state = "SOLD OUT" %}
+  {% assign registration_state = 'snippets.product_registration_state.sold_out' | t %}
 {% endif %}
 
-<span class="ProductGridItem__price uppercase">{{ registration_state }}</span>
+<span class="ProductGridItem__price text-left pl1_5 uppercase">{{ registration_state }}</span>

--- a/theme/styles/snippets/product-grid-item.scss
+++ b/theme/styles/snippets/product-grid-item.scss
@@ -46,6 +46,7 @@
 
   &__price {
     padding-left: 1.5rem;
+    text-align: right;
   }
 
   &[data-fade-in="true"] {

--- a/theme/styles/snippets/product-grid-item.scss
+++ b/theme/styles/snippets/product-grid-item.scss
@@ -44,6 +44,10 @@
     letter-spacing: 0.0275rem;
   }
 
+  &__price {
+    padding-left: 1.5rem;
+  }
+
   &[data-fade-in="true"] {
     .ProductGridItem__image {
       animation: $transition-duration-long cubic-bezier(0.25, 0.46, 0.45, 0.94)1 normal forwards animation-fade-in;

--- a/theme/styles/snippets/product-grid-item.scss
+++ b/theme/styles/snippets/product-grid-item.scss
@@ -44,11 +44,6 @@
     letter-spacing: 0.0275rem;
   }
 
-  &__price {
-    padding-left: 1.5rem;
-    text-align: right;
-  }
-
   &[data-fade-in="true"] {
     .ProductGridItem__image {
       animation: $transition-duration-long cubic-bezier(0.25, 0.46, 0.45, 0.94)1 normal forwards animation-fade-in;


### PR DESCRIPTION
### Description

This PR updates the text that is usually the price of a product on a product grid item with the registration or booking status if the product is an event or course.

To determine the booking status for events and courses, I used this guide: https://docs.shopifybookings.com/liquid-rendering/bookable-status

There is currently no design or designated copy to use for the status so I just used what makes sense but it's easy to change in QA. I'm also thinking of making these global fields in Accentuate so we can change the copy of the status without a code change but it's not super necessary. 

**Note**: I also changed the logic that checks the product type to use the first variant regardless of it being available or not instead of using the first available variant because currently on the website, past events don't get a product type on their grid item because their variant is not available. See the Pasta workshop 1 product here: https://index-space.org/collections/courses

### Possible statuses and when they're applied:

**$XXX**
The actual price is shown if it's any product other than a course/event, and if it's an upcoming course/event in the future with a fee that is not sold out

**Upcoming**
This is shown when the course/event is in the future and is not sold out

**Past**
This is shown when the course/event's date has already passed (today's date > event/course end date)

**Registration closed**
This is shown when the course/event is currently going on (today's date > event/course start date)

**Sold **out****
This is shown when the course/event is in the future but it's all sold out.

Notes:
- I wonder if sold-out is needed? Maybe just show a price and customer sees it's sold out on the page itself.
- Instead of "Upcoming", it could just say "Free"?


### Type(s) of changes

- [x] Update to an existing feature

### Motivation for PR

https://github.com/sanctuarycomputer/nunu/issues/181

### How Has This Been Tested?

The products ATM have enough different types to test the "Past", "Upcoming", and "Registration closed" statuses. Of course products like books show the price as well but that's different than showing the price for a course/event.

Question: Should I create a sample course/event to test this through Shopify bookings? Would I test this by creating a new collection? @chrismekim 

**Links (Check out courses, events, and shop collections)**
Preview: https://a5efaeryhj0k4fqm-52674822324.shopifypreview.com

### Applicable screenshots:

![Screen Shot 2021-05-21 at 4 07 03 PM](https://user-images.githubusercontent.com/14059589/119192747-9d0ca880-ba4e-11eb-8738-b606ddb4f911.png)

### Follow-up PR

I'm thinking of creating an issue and PR to make the "Add to cart" button show "Sold-out" if the event was in the past so Elie doesn't have to manually make the product unavailable. Although she still should, this just makes sure the website makes sense in case she forgets.

Ideally, Shopify bookings should set the inventory of past bookable products to 0 itself.
