### PR TITLE
Qa/product description subnav

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "typescript": "^4.1.3",
-    "what-input": "^5.2.10"
+    "what-input": "^5.2.10",
+    "zenscroll": "^4.0.2"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^3.1.3",

--- a/theme/scripts/index.ts
+++ b/theme/scripts/index.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/browser";
 import { Integrations } from "@sentry/tracing";
 import 'what-input'
+import "zenscroll"
 
 declare global {
   interface Window {

--- a/theme/scripts/productDescription.ts
+++ b/theme/scripts/productDescription.ts
@@ -1,6 +1,6 @@
 // Pixel value that's added to the height of the sticky header
 // and used to check which section is within the page that lead to best experience
-const STICKY_HEIGHT_BUFFER = 16;
+const STICKY_HEIGHT_BUFFER = 24;
 
 export default (function () {
   const ProductDescription = {

--- a/theme/snippets/nav.liquid
+++ b/theme/snippets/nav.liquid
@@ -1,6 +1,6 @@
 {% assign show_border_bottom = true %}
 
-{% if request.page_type == 'collection' or request.page_type == 'product' %}
+{% if request.page_type == 'collection' %}
   {% assign show_border_bottom = false %}
 {% endif %}
 

--- a/theme/snippets/product-description.liquid
+++ b/theme/snippets/product-description.liquid
@@ -6,7 +6,7 @@
 {% endif %}
 
 {% if is_course %}
-  <div data-product-description-tabs-wrapper class="ProductDescription__tabs sticky pt1_25 pb_5 site-padding-x z-description flex flex-row items flex-nowrap overflow-x-auto overflow-y-hidden w100">
+  <div data-product-description-tabs-wrapper class="ProductDescription__tabs border-bottom-black sticky pt_5 pb_5 site-padding-x z-description flex flex-row items flex-nowrap overflow-x-auto overflow-y-hidden w100">
     {% for title in product.metafields.accentuate.title %}
       <a 
         data-product-description-tab 
@@ -16,7 +16,7 @@
       </a>
     {% endfor %}
   </div>
-  <div class="ProductDescription site-padding-x">
+  <div class="ProductDescription site-padding-x py1_25">
     {% for markdown in product.metafields.accentuate.markdown %}
         {% assign id = product.metafields.accentuate.title[forloop.index0] | handleize %}
         <div id="{{ id }}" class="ProductDescription__content" data-product-description-content>

--- a/theme/styles/settings/_vars.scss
+++ b/theme/styles/settings/_vars.scss
@@ -22,9 +22,9 @@ $nav-height: 2.925rem;
 $nav-height-md: 3.036875rem;
 $nav-height-lg-xl: 3.875rem;
 
-$product-tabs-height: 4.737rem;
-$product-tabs-height-md: 3.9rem;
-$product-tabs-height-lg-xl: 5rem;
+$product-tabs-height: 3.1125rem;
+$product-tabs-height-md: 3.2244rem;
+$product-tabs-height-lg-xl: 4.3494rem;
 
 $cart-checkout-container-height: 3.5625rem;
 $cart-checkout-container-height-lg: 3.875rem;

--- a/theme/styles/snippets/product-description.scss
+++ b/theme/styles/snippets/product-description.scss
@@ -20,17 +20,17 @@
       padding-bottom: 0;
     }
 
-    padding-top: calc(#{$nav-height} + #{$product-tabs-height} + 0.5rem); 
-    margin-top: calc(-#{$nav-height} - #{$product-tabs-height} - 0.5rem); 
+    padding-top: calc(#{$nav-height} + #{$product-tabs-height}); 
+    margin-top: calc(-#{$nav-height} - #{$product-tabs-height}); 
 
     @include media('md-up') {
-      padding-top: calc(#{$nav-height-md} + #{$product-tabs-height-md} + 0.5rem);
-      margin-top: calc(-#{$nav-height-md} - #{$product-tabs-height-md} - 0.5rem);
+      padding-top: calc(#{$nav-height-md} + #{$product-tabs-height-md});
+      margin-top: calc(-#{$nav-height-md} - #{$product-tabs-height-md});
     }
   
     @include media('lg-xl-up') {
-      padding-top: calc(#{$nav-height-lg-xl} + #{$product-tabs-height-lg-xl} + 0.5rem);
-      margin-top: calc(-#{$nav-height-lg-xl} - #{$product-tabs-height-lg-xl} - 0.5rem);
+      padding-top: calc(#{$nav-height-lg-xl} + #{$product-tabs-height-lg-xl});
+      margin-top: calc(-#{$nav-height-lg-xl} - #{$product-tabs-height-lg-xl});
     }
   }
 

--- a/theme/styles/snippets/product-description.scss
+++ b/theme/styles/snippets/product-description.scss
@@ -20,17 +20,17 @@
       padding-bottom: 0;
     }
 
-    padding-top: calc(#{$nav-height} + #{$product-tabs-height}); 
-    margin-top: calc(-#{$nav-height} - #{$product-tabs-height}); 
+    padding-top: calc(#{$nav-height} + #{$product-tabs-height} + 0.5rem); 
+    margin-top: calc(-#{$nav-height} - #{$product-tabs-height} - 0.5rem); 
 
     @include media('md-up') {
-      padding-top: calc(#{$nav-height-md} + #{$product-tabs-height-md});
-      margin-top: calc(-#{$nav-height-md} - #{$product-tabs-height-md});
+      padding-top: calc(#{$nav-height-md} + #{$product-tabs-height-md} + 0.5rem);
+      margin-top: calc(-#{$nav-height-md} - #{$product-tabs-height-md} - 0.5rem);
     }
   
     @include media('lg-xl-up') {
-      padding-top: calc(#{$nav-height-lg-xl} + #{$product-tabs-height-lg-xl});
-      margin-top: calc(-#{$nav-height-lg-xl} - #{$product-tabs-height-lg-xl});
+      padding-top: calc(#{$nav-height-lg-xl} + #{$product-tabs-height-lg-xl} + 0.5rem);
+      margin-top: calc(-#{$nav-height-lg-xl} - #{$product-tabs-height-lg-xl} - 0.5rem);
     }
   }
 
@@ -40,6 +40,10 @@
 
     @include media('md-up') {
       top: $nav-height-md;
+    }
+
+    @include media('lg-xl-up') {
+      top: $nav-height-lg-xl;
     }
 
     -ms-overflow-style: none;  /* IE and Edge */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2731,3 +2731,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zenscroll@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/zenscroll/-/zenscroll-4.0.2.tgz#e8d5774d1c0738a47bcfa8729f3712e2deddeb25"
+  integrity sha1-6NV3TRwHOKR7z6hynzcS4t7d6yU=


### PR DESCRIPTION
## Description

QA fixes relating to the product description subnav feature on the PDP.

### Borders

I changed the rule on the main nav to show the bottom border on every page other than collections. We'll add it to collections when the new collection page design is done. 

### Smooth scroll

As I mentioned in the original PR, smooth scroll did not work on Safari. I researched to determine how to make it possible and the best solution seemed to be this zenscroll library: https://github.com/zengabor/zenscroll

It's only 1kb and vanilla JS so I think it's fine. I tried implementing another solution I found online where I would add the code myself but it was being difficult. We'd also need to add code to check if it was even needed first. Zenscroll deals with all the complexity and it works from what I tested.

Let me know if this sounds alright, otherwise, we can try to implement what zenscroll does ourselves.

### Type(s) of changes

- [x] Bug fix

### Motivation for PR

**QA tickets addressed in this PR:**
https://www.notion.so/garden3d/Bottom-rule-on-Tabbed-nav-area-ea0a61d869bf4953a1aae92a393a4e4e
https://www.notion.so/garden3d/Smooth-animation-on-Jump-for-tabbed-content-area-d7370d7a991543b18ce66813d579990a
https://www.notion.so/garden3d/Bottom-Rule-on-Nav-76351180d0f84277ba62a1ab24041f16

### How Has This Been Tested?

I tested on my laptop and my phone. The main thing to test for is whether the smooth scroll on Safari works.

Share preview: https://cdz2de4g5l0muy2w-52674822324.shopifypreview.com
Course product: https://cdz2de4g5l0muy2w-52674822324.shopifypreview.com/products/animation-overview

### Applicable screenshots:

![Screen Shot 2021-05-31 at 10 36 59 AM](https://user-images.githubusercontent.com/14059589/120209000-24e77500-c1fc-11eb-946f-8e8f4346354b.png)
