### PR TITLE
Feature/181-186-update-PDP-with-product-state-and-free

### DIFF
--- a/theme/locales/en.default.json
+++ b/theme/locales/en.default.json
@@ -146,7 +146,7 @@
       },
       "registration_closed_btn": {
         "aria_label": "Registration is closed",
-        "text": "Registration closed"
+        "text": "Closed"
       },
       "sold_out_btn": {
         "aria_label": "Product is sold out",

--- a/theme/locales/en.default.json
+++ b/theme/locales/en.default.json
@@ -110,6 +110,9 @@
       "sold_out": "Sold out",
       "registration_closed": "Registration closed"
     },
+    "product_info": {
+      "free": "Free"
+    },
     "cookie_consent": {
       "alt": "Yellow circle cookie consent pop up",
       "aria_label": "Cookie Consent pop up"
@@ -136,6 +139,10 @@
       },
       "add_to_cart_btn_error": {
         "text": "This item could not be added to your cart."
+      },
+      "past_btn": {
+        "aria_label": "This offering occured in the past.",
+        "text": "Past"
       },
       "registration_closed_btn": {
         "aria_label": "Registration is closed",

--- a/theme/snippets/add-to-cart-container.liquid
+++ b/theme/snippets/add-to-cart-container.liquid
@@ -7,6 +7,9 @@
 {% endif %}
 {% assign lowercase_product_type = product_type | downcase %}
 
+{% capture button_label %}{{"snippets.add_to_cart_container.add_to_cart_btn.text" | t }}{% endcapture %}
+{% assign button_disabled = false %}
+
 <!-- Assign label and disabled state to add to cart button -->
 {% if lowercase_product_type == "event" or lowercase_product_type == "course" %}
 
@@ -24,9 +27,6 @@
     {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
   {% endif %}
 
-  {% capture button_label %}{{"snippets.add_to_cart_container.add_to_cart_btn.text" | t }}{% endcapture %}
-  {% assign button_disabled = false %}
-
   {% if todays_date > ends_at %}
     {% capture button_label %}{{"snippets.add_to_cart_container.past_btn.text" | t }}{% endcapture %}
     {% assign button_disabled = true %}
@@ -41,8 +41,6 @@
 {% else %}
 
   <!-- For regular products (non bookings) -->
-  {% capture button_label %}{{"snippets.add_to_cart_container.add_to_cart_btn.text" | t }}{% endcapture %}
-  {% assign button_disabled = false %}
   {% if product.available != true %}
     {% capture button_label %}{{"snippets.add_to_cart_container.sold_out_btn.text" | t }}{% endcapture %}
     {% assign button_disabled = true %}

--- a/theme/snippets/add-to-cart-container.liquid
+++ b/theme/snippets/add-to-cart-container.liquid
@@ -1,9 +1,53 @@
+<!-- Get product type -->
+{% assign product_type = "" %}
+{% if product.variants[0].metafields.bookings != blank %}
+  {% assign product_type = product.variants[0].metafields.bookings.bookable_type %}
+{% else %}
+  {% assign product_type = product.type %}
+{% endif %}
+{% assign lowercase_product_type = product_type | downcase %}
+
 <!-- Assign label and disabled state to add to cart button -->
-{% capture button_label %}{{"snippets.add_to_cart_container.add_to_cart_btn.text" | t }}{% endcapture %}
-{% assign button_disabled = false %}
-{% if product.available != true %}
-  {% capture button_label %}{{"snippets.add_to_cart_container.sold_out_btn.text" | t }}{% endcapture %}
-  {% assign button_disabled = true %}
+{% if lowercase_product_type == "event" or lowercase_product_type == "course" %}
+
+  <!-- For bookings products -->
+  {% assign current_variant = product.selected_or_first_available_variant %}
+  {% assign bookings_metafields = current_variant.metafields.bookings %}
+  {% assign todays_date = 'now' | date: '%s' %}
+
+  {% if lowercase_product_type == "course" %}
+    {% assign sessions_sorted = bookings_metafields.sessions | sort: 'starts_at' %}
+    {% assign starts_at = sessions_sorted.first.starts_at | date: '%s' %}
+    {% assign ends_at = sessions_sorted.last.ends_at | date: '%s' %}
+  {% elsif lowercase_product_type == "event" %}
+    {% assign starts_at = bookings_metafields.starts_at | date: '%s' %}
+    {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
+  {% endif %}
+
+  {% capture button_label %}{{"snippets.add_to_cart_container.add_to_cart_btn.text" | t }}{% endcapture %}
+  {% assign button_disabled = false %}
+
+  {% if todays_date > ends_at %}
+    {% capture button_label %}{{"snippets.add_to_cart_container.past_btn.text" | t }}{% endcapture %}
+    {% assign button_disabled = true %}
+  {% elsif todays_date > starts_at %}
+    {% capture button_label %}{{"snippets.add_to_cart_container.registration_closed_btn.text" | t }}{% endcapture %}
+    {% assign button_disabled = true %}
+  {% elsif todays_date < starts_at and current_variant.available != true %}
+    {% capture button_label %}{{"snippets.add_to_cart_container.sold_out_btn.text" | t }}{% endcapture %}
+    {% assign button_disabled = true %}
+  {% endif %}
+
+{% else %}
+
+  <!-- For regular products (non bookings) -->
+  {% capture button_label %}{{"snippets.add_to_cart_container.add_to_cart_btn.text" | t }}{% endcapture %}
+  {% assign button_disabled = false %}
+  {% if product.available != true %}
+    {% capture button_label %}{{"snippets.add_to_cart_container.sold_out_btn.text" | t }}{% endcapture %}
+    {% assign button_disabled = true %}
+  {% endif %}
+
 {% endif %}
 
 <div class="AddToCartContainer px_625 md:px0">

--- a/theme/snippets/product-info.liquid
+++ b/theme/snippets/product-info.liquid
@@ -1,4 +1,8 @@
 {% assign brief_product_description = product.metafields.accentuate.brief_product_description %}
+{% assign product_price = product.price | money_without_trailing_zeros %}
+{% if product.price == 0 %}
+  {% assign product_price = 'snippets.product_info.free' | t %}
+{% endif %}
 
 <!-- Check if product already exists in cart -->
 {% for item in cart.items %}
@@ -18,11 +22,11 @@
   {% assign product_type = product.type %}
 {% endif %}
 
-<div class="ProductInfo flex flex-col z-1 col-12 md:col-3 md:pr2_5 px_625 md:pl_75">
+<div class="ProductInfo flex flex-col z-1 col-12 md:col-4 xl:col-3 md:pr2_5 px_625 md:pl_75">
   <span class="ProductInfo__product-details flex flex-col sans-light-sm color-black">
     <div class="serif flex flex-row justify-between">
-      <h1 class="ProductInfo__title md:pr_5">{{ product.title }}</h1>
-      <span class="ProductInfo__price text-right">{{ product.price | money_without_trailing_zeros }}</span>
+      <h1 class="ProductInfo__title md:pr1_5">{{ product.title }}</h1>
+      <span class="ProductInfo__price text-right uppercase">{{ product_price }}</span>
     </div>
     <span class="sans-xs pt_625 pb1_5 md:pt1_5 md:pb1_125">
       {{ brief_product_description }}

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -8,14 +8,14 @@
   <div class="Product_hero border-bottom-black flex flex-col md:flex-row pb_75 md:pb_625">
     {% render 'product-info' product: product %}
     {% if product.images.size > 1 %}
-    {% include 'product-images-slider' %}
+      {% include 'product-images-slider' %}
     {% else %}
-    <div class="Product__hero-image-outer-container px_625 md:px0 col-12 md:col-9">
-      <div class="Product__hero-image-container radius-xl flex items-center justify-center p2 md:p3 bg-color-black">
-        <img src="{{ featured_image | img_url: '1200x' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg" class="fit-contain w100">
+      <div class="Product__hero-image-outer-container px_625 md:px0 col-12 md:col-9">
+        <div class="Product__hero-image-container radius-xl flex items-center justify-center p2 md:p3 bg-color-black">
+          <img src="{{ featured_image | img_url: '1200x' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg" class="fit-contain w100">
+        </div>
       </div>
-    </div>
-  {% endif %}
+    {% endif %}
     <div class="flex flex-col md:none">
       {% render 'product-instructor' product: product %}
       <div class="px_625 pt2">


### PR DESCRIPTION
## Description

This PR is an extension of https://github.com/sanctuarycomputer/nunu/pull/183 and it updates the PDP with two main changes:

1. Products that have a price of $0 now say "FREE" on the PDP instead of $0.
2. The add to cart button now has more detail for bookable products and is labelled by the product state and is disabled/enabled accordingly

All labels have been added to the locales so they are easily changeable.

The registration state logic is copied from `product-registration-state.liquid` snippet. The top of the file with Liquid gets quite large though but since all the logic is only needed for the add to cart button, there's no reason to do this logic beforehand or separate it.

I also had to make slight CSS changes to the spacing and width so everything still looks right.

### Type(s) of changes

- [x] New feature
- [x] Update to an existing feature

### Motivation for PR

https://github.com/sanctuarycomputer/nunu/issues/186
https://github.com/sanctuarycomputer/nunu/issues/181

### How Has This Been Tested?

Tested different screen sizes to make sure the different button labels fit.

**Share preview link:** https://wr0fl0mwlaacs4ix-52674822324.shopifypreview.com

In the past bookable product and free product: https://index-space.org/products/disobey-a-playful-guide-to-disobedience-creativity-and-rebellion
Sold out bookable product: https://index-space.org/products/testinjg-sold-out-1
Registration closed bookable product: https://index-space.org/products/testing-registration-closed
Upcoming bookable product: https://index-space.org/products/testing

### Applicable screenshots:

![Screen Shot 2021-05-31 at 1 26 59 PM](https://user-images.githubusercontent.com/14059589/120225790-e2ca2d80-c213-11eb-8686-62efeb4decac.png)

### Question

All the locales for the button labels also have aria-labels but they're never used in the code? It doesn't seem like the button itself needs a label because it has clear text within it so should these be used elsewhere or removed from the locales? @chrismekim @sepowitz 