### PR TITLE
Qa/pdp form updates

### DIFF
--- a/theme/snippets/add-to-cart-container.liquid
+++ b/theme/snippets/add-to-cart-container.liquid
@@ -50,23 +50,23 @@
 
 <div class="AddToCartContainer px_625 md:px0">
   <form data-product-add-to-cart-form data-product-type={{product_type}} action="/cart/add" method="post" enctype="multipart/form-data" id="AddToCartForm">
-    <div class="AddToCartContainer__quantity-select-wrapper overflow-hidden relative {% if product.variants.size <= 1 %} mb1_75 {% endif %}">
+    <div class="AddToCartContainer__quantity-select-wrapper overflow-hidden relative {% if product.variants.size <= 1 %} mb1_875 {% endif %}">
       <label for="quantity" type="number" name="quantity" aria-label={{"snippets.add_to_cart_container.quantity_spinner.label" | t }}></label>
-      <select class="sans-xs uppercase radius-xs border-black w100 pl1_125 py_5" name="quantity" id="Quantity" >
+      <select class="sans-xs uppercase radius-xs border-black w100 pl1_125 pb_875 pt1" name="quantity" id="Quantity" >
         <option value="1" selected="selected">1</option>
-        {% for i in (2...25) %}
+        {% for i in (2...5) %}
           <option value="{{ i }}">{{ i }}</option>
         {% endfor %}       
       </select>
     </div>
-    <div class="AddToCartContainer__variant-select-wrapper overflow-hidden relative mt_625 mb1_75{% if product.variants.size <= 1 %} none {% endif %}">
+    <div class="AddToCartContainer__variant-select-wrapper overflow-hidden relative mt_625 mb1_875{% if product.variants.size <= 1 %} none {% endif %}">
       <label for="variant" type="text" name="variant" aria-label={{"snippets.add_to_cart_container.variant_select.label" | t }}></label>
       {% if product.variants.size <= 1 %}
-        <select class="sans-xs uppercase radius-xs border-black w100 pl1_125 py_5" name="variant">
+        <select class="sans-xs uppercase radius-xs border-black w100 pl1_125 pb_875 pt1" name="variant">
           <option value="{{ product.first_available_variant.id }}" selected="selected">{{ product.first_available_variant.id }}</option>
         </select>
       {% else %}
-        <select class="sans-xs uppercase radius-xs border-black w100 pl1_125 py_5" name="variant" >
+        <select class="sans-xs uppercase radius-xs border-black w100 pl1_125 pb_875 pt1" name="variant" >
           {% for variant in product.variants %}
             <option value="{{ variant.id }}" {% if variant.available != true %} disabled {% endif %}>
               {{ variant.title }}
@@ -76,7 +76,7 @@
       {% endif %}
     </div>
     <button {% if isDesktop %} data-desktop-product-add-to-cart-button {% else %} data-mobile-product-add-to-cart-button {% endif %}
-    {% if button_disabled %} disabled {% endif %} class="w100 color-white uppercase sans-light-sm radius-xs bg-color-black py_75" type="submit" name="add" id="AddToCart">
+    {% if button_disabled %} disabled {% endif %} class="AddToCartContainer__button w100 color-white uppercase sans-light-sm radius-xs bg-color-black pb_5 pt_625" type="submit" name="add" id="AddToCart">
       {{button_label}}
     </button>
     <div {% if isDesktop %} data-desktop-product-add-to-cart-button-error {% else %} data-mobile-product-add-to-cart-button-error {% endif %} class="AddToCartContainer__error-message--inactive color-red sans-xs py_625 md:pb0 md:pt_625 transition-short">

--- a/theme/snippets/product-info.liquid
+++ b/theme/snippets/product-info.liquid
@@ -28,7 +28,7 @@
       <h1 class="ProductInfo__title md:pr1_5">{{ product.title }}</h1>
       <span class="ProductInfo__price text-right uppercase">{{ product_price }}</span>
     </div>
-    <span class="sans-xs pt_625 pb1_5 md:pt1_5 md:pb1_125">
+    <span class="sans-xs pt_625 pb1_5 md:pb1_875">
       {{ brief_product_description }}
     </span>
     <div class="none md:flex md:flex-col">

--- a/theme/snippets/product-instructor.liquid
+++ b/theme/snippets/product-instructor.liquid
@@ -22,7 +22,7 @@
 {% endif %}
 
 {% if current_variant.metafields.bookings != blank %}
-  <span class="ProductInstructor color-black uppercase flex flex-row items-center pt1_25 md:pt0 pl_625 md:pl0 md:pb2">
+  <span class="ProductInstructor color-black uppercase flex flex-row items-center pt1_25 md:pt0 pl_625 md:pl0 md:pb1_875">
     {% if vendor_avatar != blank %}
       <img class="ProductInstructor__avatar radius-xs lg:radius-sm w100 fit-cover" alt={{ 'snippets.product_vendor.avatar.alt' | t }} src={{vendor_avatar}} >
     {% endif %}

--- a/theme/snippets/product-text-fields.liquid
+++ b/theme/snippets/product-text-fields.liquid
@@ -1,9 +1,23 @@
 {% if product.metafields.accentuate.product_text_field_text %}
-<div class="ProductInfo__text-fields sans-xs">
-  {% for value in product.metafields.accentuate.product_text_field_text %} 
-    <div class="pb1_25">
-      {{ value }}
-    </div>
-  {% endfor %}
-</div>
+  <div class="ProductInfo__text-fields sans-xs">
+    {% if product.metafields.accentuate.product_text_field_icon %}
+      {% for value in product.metafields.accentuate.product_text_field_text %}
+        <div class="pb1_25 flex items-center">
+          {% assign icon = product.metafields.accentuate.product_text_field_icon[forloop.index0].first %}
+          <img 
+            src="{{ icon.src }}"
+            alt="{%- if icon.alt != "" -%} {{- icon.alt -}} {%- else -%} {{- value -}} {%- endif -%}"
+            class="hauto mr_5"
+          />
+          {{- value -}}
+        </div>
+      {% endfor %}
+    {% else %}
+      {% for value in product.metafields.accentuate.product_text_field_text %}
+        <div class="pb1_25 flex items-center">
+          {{ value }}
+        </div>
+      {% endfor %}
+    {% endif %}
+  </div>
 {% endif %}

--- a/theme/styles/snippets/add-to-cart-container.scss
+++ b/theme/styles/snippets/add-to-cart-container.scss
@@ -6,7 +6,7 @@
         pointer-events: none; /* ▼ click triggers dropdown */
         position: absolute;
         right: 1.125rem;
-        top: 0.6rem;
+        top: 1.125rem;
         z-index: 1;
     }
   }
@@ -21,6 +21,12 @@
       opacity: 1;
       transform: translate3d(0, 0, 0);
     };
+  }
+
+  &__button {
+    font-size: 1.875rem;
+    line-height: 1.6875rem;
+    letter-spacing: 0.0275rem;
   }
 
   select {

--- a/theme/styles/snippets/product-info.scss
+++ b/theme/styles/snippets/product-info.scss
@@ -17,5 +17,9 @@
     div {
       letter-spacing: 0.0275rem;
     }
+
+    img {
+      width: 20px;
+    }
   }
 }

--- a/theme/styles/snippets/product-info.scss
+++ b/theme/styles/snippets/product-info.scss
@@ -10,7 +10,12 @@
     }
   }
 
-  &__text-fields div {
-    letter-spacing: 0.0275rem;
+  &__text-fields {
+
+    padding-bottom: 0.65rem;
+
+    div {
+      letter-spacing: 0.0275rem;
+    }
   }
 }

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -4,7 +4,7 @@
 {% assign related_products_handles = product.metafields.accentuate.related_products | split: '|' %}
 {% assign product_description = product.metafields.accentuate.product_description %}
 
-<div class="Product pt_625 md:pt1_25">
+<div class="Product pt1 md:pt1_25">
   <div class="Product_hero border-bottom-black flex flex-col md:flex-row pb_75 md:pb_625">
     {% render 'product-info' product: product %}
     {% if product.images.size > 1 %}


### PR DESCRIPTION
## Description

This PR targets a bunch of small QA requests related to the product info and add to cart form on PDP. I'll list them out below a long with any details I think are worth pointing out about them: **( Click on them to see ticket on notion )**

### **[Quantity Area Limit](https://www.notion.so/garden3d/Quantity-Area-Limit-3afc512c979a41e3860f7965f4371cdf)**
Change the quantity limit from 25 to 5. I only found one location where this was set. Let me know if this affects anything else but I don't think it would.

### **[Center Vertical Alignment of Quantity Arrow](https://www.notion.so/garden3d/Center-Vertical-Alignment-of-Quantity-Arrow-015e8de6607346269d90084ec2b695f4) and [Button/Select sizing](https://www.notion.so/garden3d/Button-Quantity-sizing-78ee6aebcbe34c9c82e81dace225f70f)**
It seemed like Safari would apply the `top` spacing on the select arrow icon a bit differently than chrome which made it look off-center. I just made it larger so it looks more centered on both. 
![Screen Shot 2021-06-03 at 4 55 33 PM](https://user-images.githubusercontent.com/14059589/120710823-9e959200-c48c-11eb-96b3-3885c7856a27.png)

Additionally, the font has some extra spacing on the bottom, so I apply a different value to top and bottom padding so it looks more even visually.

I changed the font size styling on the button to keep it the same size regardless of the screen. I found that the smaller font made the button look odd especially when the select box remained large. There is enough space to keep it the same size and the Figma mocks actually maintain the same size on mobile and desktop.

**On theme**
![Screen Shot 2021-06-03 at 4 57 04 PM](https://user-images.githubusercontent.com/14059589/120710936-c4229b80-c48c-11eb-8524-9283662e0fd1.png)

**On Figma**
![Screen Shot 2021-06-03 at 4 57 11 PM](https://user-images.githubusercontent.com/14059589/120710938-c553c880-c48c-11eb-9041-bd4eebec0ece.png)

### [**Hero area spacing**](https://www.notion.so/garden3d/Hero-Area-Spacing-ebc33792f5ee47c4995edb2ebe6dd060)
Nothing special here, just copied spacing from Figma to match what Jake mentioned in the ticket (30px for desktop).

### [Metadata Icon sizing](https://www.notion.so/garden3d/Metadata-Icon-sizing-6257b75b2a1046ab8f4f172ffdd80d0e)
As mentioned in the ticket, the icons are now svgs you can upload on Accentuate instead of through the text. I made it so it only uses the svg field if it exists and otherwise just renders the text field like before to keep it 'graceful'.

I used the [mediav2 field of Accentuate](https://my.accentuate.io/c/field-definitions/media-v2-fields) so every image can actually be an array of images which is why I use `.first` before using any properties. Additionally, I use the svg within an `img` tag instead of making it inline svg because I can add an `alt` attribute this way. Also, Accentuate said this saves space.

### Type(s) of changes

- [x] Bug fix
- [x] Update to an existing feature

### Motivation for PR

I linked the tickets on the software backlog notion board above for each QA request ^

### How Has This Been Tested?

Mainly tested on Chrome and Safari since there are some differences with spacing between them which I tried to fix.

**Share preview:** https://4j0pc9voib924b4y-52674822324.shopifypreview.com
**Good product to test:** https://4j0pc9voib924b4y-52674822324.shopifypreview.com/products/anthropocene-copy

Check out a course to see the graceful view of the metafields without an icon.