### PR TITLE
[DO NOT MERGE] QA: Make Product with Single Hero Image Full Width

### DIFF
--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -11,7 +11,7 @@
       {% include 'product-images-slider' %}
     {% else %}
       <div class="Product__hero-image-outer-container px_625 md:px0 col-12 md:col-9">
-        <div class="Product__hero-image-container radius-xl flex items-center justify-center w100 h100 overflow-hidden bg-color-black">
+        <div class="Product__hero-image-container radius-xl flex items-center justify-center w100 h100 overflow-hidden">
           <img src="{{ featured_image | img_url: '1200x' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg" class="fit-contain w100">
         </div>
       </div>

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -11,7 +11,7 @@
       {% include 'product-images-slider' %}
     {% else %}
       <div class="Product__hero-image-outer-container px_625 md:px0 col-12 md:col-9">
-        <div class="Product__hero-image-container radius-xl flex items-center justify-center p2 md:p3 bg-color-black">
+        <div class="Product__hero-image-container radius-xl flex items-center justify-center w100 h100 overflow-hidden bg-color-black">
           <img src="{{ featured_image | img_url: '1200x' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg" class="fit-contain w100">
         </div>
       </div>

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -10,9 +10,9 @@
     {% if product.images.size > 1 %}
       {% include 'product-images-slider' %}
     {% else %}
-      <div class="Product__hero-image-outer-container px_625 md:px0 col-12 md:col-9">
+      <div class="Product__hero-image-outer-container px_625 md:px0 col-12 md:col-9 md:mr_625">
         <div class="Product__hero-image-container radius-xl flex items-center justify-center w100 h100 overflow-hidden">
-          <img src="{{ featured_image | img_url: '1200x' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg" class="fit-cover w100">
+          <img src="{{ featured_image | img_url: '1200x' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg" class="fit-cover w100 h100">
         </div>
       </div>
     {% endif %}

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -12,7 +12,7 @@
     {% else %}
       <div class="Product__hero-image-outer-container px_625 md:px0 col-12 md:col-9">
         <div class="Product__hero-image-container radius-xl flex items-center justify-center w100 h100 overflow-hidden">
-          <img src="{{ featured_image | img_url: '1200x' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg" class="fit-contain w100">
+          <img src="{{ featured_image | img_url: '1200x' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg" class="fit-cover w100">
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- If a Product has a single image, it should be full width.
- Removed the black background because XXIX will be updating photos to include an image with a black background if needed. Generally images will be full bleed (no black background), or product shots with a black background.
**NOTE: Pls review but do not merge because this feature will go live some time in the future, after PDP updates are pushed live, because XXIX wants time to change all the images.** 

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://kaczgl5wvq5k0961-52674822324.shopifypreview.com

View an event or product, most have one image only!
### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->
Ex of how a full width image should look (one without the black background XXIX will add) 
![image](https://user-images.githubusercontent.com/43737723/120867619-22ac5000-c547-11eb-9de1-7fb5126b7428.png)

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
