### PR TITLE
Qa/pdp button and spacing

### DIFF
--- a/theme/snippets/product-info.liquid
+++ b/theme/snippets/product-info.liquid
@@ -24,13 +24,15 @@
 
 <div class="ProductInfo flex flex-col z-1 col-12 md:col-4 xl:col-3 md:pr2_5 px_625 md:pl_75">
   <span class="ProductInfo__product-details flex flex-col sans-light-sm color-black">
-    <div class="serif flex flex-row justify-between">
+    <div class="serif flex flex-row justify-between {% if brief_product_description == blank %} pb1_25 {% endif %}">
       <h1 class="ProductInfo__title md:pr1_5">{{ product.title }}</h1>
       <span class="ProductInfo__price text-right uppercase">{{ product_price }}</span>
     </div>
-    <span class="sans-xs pt_625 pb1_5 md:pb1_875">
-      {{ brief_product_description }}
-    </span>
+    {% if brief_product_description != blank %}
+      <span class="sans-xs pt1_25 pb1_25 md:pb1_875">
+        {{ brief_product_description }}
+      </span>
+    {% endif %}
     <div class="none md:flex md:flex-col">
       {% render 'product-instructor' product: product %}
       {% render 'product-text-fields' product: product %}

--- a/theme/styles/snippets/add-to-cart-container.scss
+++ b/theme/styles/snippets/add-to-cart-container.scss
@@ -8,6 +8,7 @@
         right: 1.125rem;
         top: 1.125rem;
         z-index: 1;
+        transform: scale(1,0.75);
     }
   }
 
@@ -31,6 +32,7 @@
 
   select {
     /* remove default caret */
+    margin: 0;
     -webkit-appearance: none; /* webkit browsers */
     -moz-appearance: none; /* firefox */
     appearance: none; /* modern browsers */

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -5,7 +5,7 @@
 {% assign product_description = product.metafields.accentuate.product_description %}
 
 <div class="Product pt1 md:pt1_25">
-  <div class="Product_hero border-bottom-black flex flex-col md:flex-row pb_75 md:pb_625">
+  <div class="Product_hero border-bottom-black flex flex-col md:flex-row md:pb_625">
     {% render 'product-info' product: product %}
     {% if product.images.size > 1 %}
       {% include 'product-images-slider' %}


### PR DESCRIPTION
### Description

This PR fixes two small QA tickets that had additional changes.

https://www.notion.so/garden3d/Hero-Area-Spacing-ebc33792f5ee47c4995edb2ebe6dd060
Padding around components in the product info section. There was a case where the description element still was rendered if the description was blank causing extra space. I now conditionally render the description and add the correct spacing. Additionally, added 10px of additional padding below the title as Jake requested.

https://www.notion.so/garden3d/Center-Vertical-Alignment-of-Quantity-Arrow-015e8de6607346269d90084ec2b695f4
The triangle icon on the select was looking vertically stretched and was not centered properly on safari. I used scale to make it look like the triangle on Figma and removed the native margin on the select element which allowed safari and chrome to look the same.

### Type(s) of changes

- [x] Bug fix

### Motivation for PR

https://www.notion.so/garden3d/Hero-Area-Spacing-ebc33792f5ee47c4995edb2ebe6dd060
https://www.notion.so/garden3d/Center-Vertical-Alignment-of-Quantity-Arrow-015e8de6607346269d90084ec2b695f4

### How Has This Been Tested?

Tested on a variety of products on Safari and Chrome.

Preview share link: https://uf6vov2o84xa4lzh-52674822324.shopifypreview.com
Product without description: https://uf6vov2o84xa4lzh-52674822324.shopifypreview.com/products/animation-overview

### Applicable screenshots:

**Screenshot of adjusted spacing and triangle icon**
![Screen Shot 2021-07-09 at 12 05 54 PM](https://user-images.githubusercontent.com/14059589/125106765-05baed80-e0ae-11eb-83cf-8b393fa0f719.png)
