### PR TITLE
QA: Add styling for <span> in Product Description

### DIFF
--- a/theme/styles/templates/product.scss
+++ b/theme/styles/templates/product.scss
@@ -45,7 +45,7 @@
       @extend %serif-xl;
     }
   
-    h3, p, ol, ul  {
+    h3, p, ol, ul, span {
       font-family: $serif;
       font-size: 2rem;
       line-height: 2.1rem;


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- In the Shopify Product Description editor, if you don't select Paragraph, h1, h2, etc, I think it defaults to span. We didn't have any styling for span so I've added it in this PR.

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
QA ticket: https://www.notion.so/garden3d/ba130e56c01f4d9284d8bbf6cf59ba0f?v=133f51dd370c40ad981fef24024fa8b6&p=4c7865dc18a5447aaeb92d0c6b9a76ae

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://btvc3c5d3qq49m3g-52674822324.shopifypreview.com
View /products/oase104-the-urban-household-of-metabolism

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
