### PR TITLE
QA/hide instructors if none added

### DIFF
--- a/theme/snippets/product-instructor.liquid
+++ b/theme/snippets/product-instructor.liquid
@@ -21,16 +21,16 @@
   {% endcase %}
 {% endif %}
 
-{% if current_variant.metafields.bookings != blank %}
+{% if current_variant.metafields.bookings != blank and vendor_name != blank and vendor_avatar != blank %}
   <span class="ProductInstructor color-black uppercase flex flex-row items-center pt1_25 md:pt0 pl_625 md:pl0 md:pb1_875">
     {% if vendor_avatar != blank %}
       <img class="ProductInstructor__avatar radius-xs lg:radius-sm w100 fit-cover" alt={{ 'snippets.product_vendor.avatar.alt' | t }} src={{vendor_avatar}} >
     {% endif %}
-      <span class="flex flex-col">
-        <span class="flex flex-col content-center">
-          <span class="sans-xxxs pb_25">{{ 'snippets.product_vendor.instructor' | t }}</span>
-          <span class="ProductInstructor__name">{{ vendor_name }}</span>
-        </span>
+    <span class="flex flex-col">
+      <span class="flex flex-col content-center">
+        <span class="sans-xxxs pb_25">{{ 'snippets.product_vendor.instructor' | t }}</span>
+        <span class="ProductInstructor__name">{{ vendor_name }}</span>
       </span>
+    </span>
   </span>
 {% endif %}

--- a/theme/styles/snippets/product-info.scss
+++ b/theme/styles/snippets/product-info.scss
@@ -12,7 +12,7 @@
 
   &__text-fields {
 
-    padding-bottom: 0.65rem;
+    padding-bottom: 0.625rem;
 
     div {
       letter-spacing: 0.0275rem;

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -18,7 +18,7 @@
     {% endif %}
     <div class="flex flex-col md:none">
       {% render 'product-instructor' product: product %}
-      <div class="px_625 pt2">
+      <div class="px_625 pt1_875">
         {% render 'product-text-fields' product: product %}
       </div>
       {% render 'add-to-cart-container' data_selector: 'data-mobile-product-add-to-cart-button' product: product %}


### PR DESCRIPTION
### Description

The Instructors label was showing up even though no instructor name or image was added on Accentuate. This PR just checks whether the two fields are blank or not before rendering them.

### Type(s) of changes

- [x] Bug fix

### Motivation for PR

QA Ticket: https://www.notion.so/garden3d/Hide-Instructor-label-is-no-isntructor-f663689b48d4471abdcd82097173c442

### How Has This Been Tested?

Tested on different products to ensure Instructor and Text Fields only render when they exist.

Preview Link: https://5cpio2uo8jvzrifg-52674822324.shopifypreview.com
Course without Instructor: https://5cpio2uo8jvzrifg-52674822324.shopifypreview.com/products/pasta-at-home-workshop-2-pasta-fresca-senza-uova
