### PR TITLE
[DO NOT MERGE] QA: Make PDP date icon an Accentuate custom field

### DIFF
--- a/theme/locales/en.default.json
+++ b/theme/locales/en.default.json
@@ -114,9 +114,6 @@
       "free": "Free"
     },
     "product_date": {
-      "sun_icon": {
-        "alt": "Sun icon"
-      },
       "from": "from"
     },
     "cookie_consent": {

--- a/theme/snippets/product-date.liquid
+++ b/theme/snippets/product-date.liquid
@@ -1,3 +1,6 @@
+<!-- Get Product Date Icon -->
+{% assign date_icon = shop.metafields.accentuate.product_date_icon | first %}
+
 <!-- Get product type -->
 {% assign product_type = "" %}
 {% if product.variants[0].metafields.bookings != blank %}
@@ -35,8 +38,8 @@ An event's format is "Apr 18, 2021 5:30 - 7:30pm EDT"
   <div class="ProductDate sans-xs">
     <div class="pb1_25 flex items-start">
       <img 
-        src={{ 'sun.svg' | asset_url }}
-        alt=alt={{ 'snippets.product_date.sun_icon.alt' | t }} 
+        src="{{ date_icon.src }}"
+        alt="{{ date_icon.alt }}"
         class="ProductDate__icon hauto mr_5"
       />
       <div class="flex flex-col">

--- a/theme/snippets/product-images-slider.liquid
+++ b/theme/snippets/product-images-slider.liquid
@@ -4,7 +4,7 @@
   }
 </style>
 
-<div data-product-image-slider class="ProductImagesSlider splide col-12 md:col-9 pl_625 md:pl1_25 bg-color-white">
+<div data-product-image-slider class="ProductImagesSlider splide col-12 md:col-9 pl_625 md:pl0 bg-color-white relative overflow-hidden">
   <div class="splide__track">
     <ul class="splide__list">
       {% for image in product.images %}

--- a/theme/snippets/product-info.liquid
+++ b/theme/snippets/product-info.liquid
@@ -22,7 +22,7 @@
   {% assign product_type = product.type %}
 {% endif %}
 
-<div class="ProductInfo flex flex-col z-1 col-12 md:col-3 px_625 md:pr0 md:pl_75">
+<div class="ProductInfo flex flex-col z-1 col-12 md:col-4 xl:col-3 px_625 md:pr2_5 md:pl_75">
   <span class="ProductInfo__product-details flex flex-col sans-light-sm color-black">
     <div class="serif flex flex-row justify-between {% if brief_product_description == blank %} pb1_25 {% endif %}">
       <h1 class="ProductInfo__title md:pr1_5">{{ product.title }}</h1>

--- a/theme/styles/snippets/product-grid-item.scss
+++ b/theme/styles/snippets/product-grid-item.scss
@@ -17,7 +17,8 @@
   }
 
   &__image {
-    width: 60%;
+    width: 130%;
+    max-width: 90vw;
     max-height: 13rem;
 
     @include media('xs-up') {
@@ -25,15 +26,23 @@
     }
 
     @include media('sm-up') {
+      width: 130%;
+      max-width: 18rem;
       max-height: 11rem;
+    }
+
+    @include media('md-up') {
+      max-width: 16rem;
     }
 
     @include media('lg-up') {
       max-height: 14rem;
+      max-width: 20rem;
     }
 
     @include media('xl-up') {
       max-height: 17rem;
+      max-width: 28rem;
     }
   }
 

--- a/theme/styles/snippets/product-images-slider.scss
+++ b/theme/styles/snippets/product-images-slider.scss
@@ -1,4 +1,10 @@
 .ProductImagesSlider {
+  border-radius: radius('sm');
+
+  @include media('md-up') {
+    border-radius: radius('xl');
+  }
+
   &__img {
     height: 20rem;
     border-radius: radius('sm');

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -10,7 +10,7 @@
     {% if product.images.size > 1 %}
       {% include 'product-images-slider' %}
     {% else %}
-      <div class="Product__hero-image-outer-container px_625 col-12 md:col-9 md:px1_25">
+      <div class="Product__hero-image-outer-container col-12 md:col-9 px_625 md:px0 md:pr1_25">
         <div class="Product__hero-image-container radius-xl flex items-center justify-center w100 h100 overflow-hidden">
           <img src="{{ featured_image | img_url: '1200x' }}" alt="{{ featured_image.alt | escape }}" id="ProductPhotoImg" class="fit-cover w100 h100">
         </div>


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- This PR makes the PDP date icon a "shop" level Accentuate custom field instead of a hardcoded image
Related docs in the Website Manual: https://docs.google.com/document/d/1XC4-oTJ3RPY8itahtwWSckqHQqCYO8rHDwoNCUedUlA/edit#heading=h.e7rtmgct5fu0
- Also makes a few styling adjustments so the hero slider has a [rounded border radius as you swipe](https://share.getcloudapp.com/bLuqgd0A). (Note: This non-urgent ticket came after the QA issues covered in #199, and I wanted to keep this one separate from #199 because that's our "launch ready" branch/theme)

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://3nm13lwf8cvc0ptj-52674822324.shopifypreview.com
You should see a sun icon next to a Bookings product's date.

### Applicable screenshots:
![image](https://user-images.githubusercontent.com/43737723/130870129-69ad851e-c9f6-4430-8af6-8110914fb842.png)

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
