### PR TITLE
add date-time snippet to mobile

### DIFF
--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -19,6 +19,9 @@
     <div class="flex flex-col md:none">
       {% render 'product-instructor' product: product %}
       <div class="px_625 pt1_875">
+        {% if product.variants[0].metafields.bookings != blank %}
+          {% render 'product-date' product: product %}
+        {% endif %}
         {% render 'product-text-fields' product: product %}
       </div>
       {% render 'add-to-cart-container' data_selector: 'data-mobile-product-add-to-cart-button' product: product %}


### PR DESCRIPTION
### Description

Quick fix to add the date/time snippet to the mobile view of the PDP. 

These types of problems occur because the desktop and mobile info section of the PDP is split up between the main `product` template and the `product-info` snippet. Developers have to add the same things in both spots and it's easy to miss one.

In the future, it would make sense to try and change both desktop and mobile to use `product-info` so it does not repeat. Although, if we do end up switching all of Index to headless, this may not be worth the effort since the PDP won't change too much till then.

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix

### Motivation for PR

https://garden3d.notion.site/Course-date-and-time-doesn-t-appear-on-mobile-105c7e12f38f4cd99bef845bc6d8d715

### How Has This Been Tested?

Tested on Chrome dev tools and my iphone!

### Applicable screenshots:

![IMG_A86713518330-1](https://user-images.githubusercontent.com/14059589/133364739-9f191779-1b14-4573-84cb-73c052f4eb7a.jpeg)