### PR TITLE
Make Resource Role editable in Accentuate

### DIFF
--- a/theme/snippets/product-instructor.liquid
+++ b/theme/snippets/product-instructor.liquid
@@ -28,7 +28,13 @@
     {% endif %}
     <span class="flex flex-col">
       <span class="flex flex-col content-center">
-        <span class="sans-xxxs pb_25">{{ 'snippets.product_vendor.instructor' | t }}</span>
+        <span class="sans-xxxs pb_25">
+          {% if product.metafields.accentuate.resource_role %}
+            {{ product.metafields.accentuate.resource_role }}
+          {% else %}
+            {{ 'snippets.product_vendor.instructor' | t }}
+          {% endif %}
+        </span>
         <span class="ProductInstructor__name">{{ vendor_name }}</span>
       </span>
     </span>


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- Add Resource Role field to Accentuate 
- If this field is blank, this defaults to "Instructor"

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
- Design request
### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
https://kc6cm67rleh41aqg-52674822324.shopifypreview.com

- If you visit `products/caps-lock-a-book-talk-with-ruben-pater`, the role should say "Featured Speaker".

### Applicable screenshots:
![image](https://user-images.githubusercontent.com/43737723/134419075-7ea50e63-9d82-4a8b-8a4d-ef542eda108f.png)

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
