### PR TITLE
Renames Italic fontface and adds <em> style to Markdown

### DIFF
--- a/theme/assets/fonts.css.liquid
+++ b/theme/assets/fonts.css.liquid
@@ -10,7 +10,7 @@
 }
 
 @font-face {
-  font-family: "ITCGaramondStdLtCondIta";
+  font-family: "ITCGaramondStdLtCond";
   font-style: italic;
   font-weight: 300;
   font-display: swap;

--- a/theme/styles/snippets/markdown.scss
+++ b/theme/styles/snippets/markdown.scss
@@ -1,8 +1,12 @@
 $text-max-width: 65rem;
 
 .Markdown {
-  h1, h2, h3, p, ol, ul {
+  h1, h2, h3, p, ol, ul, em {
     font-family: $serif;
+  }
+
+  em {
+    font-style: italic;
   }
 
   /* Bold class used for Dingbats Font in Home Page Intro */


### PR DESCRIPTION
### Description

This adds italic serif styles to `.Markdown` elements by renaming the italic fontface from `ITCGaramondStdLtCondIta`→ `ITCGaramondStdLtCond`, and adding an `em` style to the CSS.

This PR closes #204.

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

Sam Taylor wanted to add italics to the new patronage Join page. [Twist thread here.](https://twist.com/a/133876/ch/376069/t/2886020/)

### How Has This Been Tested?

Tested in Shopify theme preview mode

### Applicable screenshots:

![image](https://user-images.githubusercontent.com/1934813/139112871-086608fe-442f-481c-a37e-a594d3d2a98a.png)
