### PR TITLE
Feature/patreon api

### DIFF
--- a/theme/scripts/index.ts
+++ b/theme/scripts/index.ts
@@ -28,3 +28,4 @@ import "./pageTransition";
 import "./fadeIn";
 import "./magicMouse";
 import "./patronSlider";
+import "./patronsList";

--- a/theme/scripts/patronSlider.ts
+++ b/theme/scripts/patronSlider.ts
@@ -1,7 +1,6 @@
 import * as rangeSlider from "nouislider";
 import getNextSibling from "./utils/getNextSibling";
 import handleFetchJSONResponse from "./utils/handleFetchJSONResponse";
-import jsonp from "./utils/jsonp";
 
 const TIER_PRICES = [5, 10, 15, 20, 25];
 
@@ -94,12 +93,16 @@ export default (function () {
         PatronSlider.SELECTORS.patronTierName
       );
 
+      const allPatrons = await PatronSlider.fetchPatrons();
+
       PatronSlider.initializeCopy({
         handle,
         patronTierLink,
         tierCopywriting,
         patronTierName,
+        allPatrons
       });
+
       PatronSlider.bindEventListeners({
         handle,
         patronTierLink,
@@ -113,6 +116,7 @@ export default (function () {
       patronTierLink,
       tierCopywriting,
       patronTierName,
+      allPatrons
     }) {
       // Used to set the content of our slider handle
       handle.setAttribute("data-before", `$${PatronSlider.START_VALUE}`);
@@ -129,6 +133,9 @@ export default (function () {
 
       patronTierName.textContent =
         PatronSlider.PATRON_TIERS[PatronSlider.START_VALUE].name;
+
+      console.log(allPatrons);
+
     },
 
     bindEventListeners({
@@ -174,23 +181,12 @@ export default (function () {
     },
 
     async fetchPatrons() {
-
-      jsonp('https://api.index-space.org/api/pals', "c", (err, data) => {
-        if (err) {
-          console.error(err);
-          return;
-        } else {
-          console.log(data);
-        }
-      });
-
-      // return fetch("https://api.index-space.org/api/pals", {
-      //   method: "GET",
-      //   headers: {
-      //     "Content-Type": "application/json",
-      //     "Access-Control-Allow-Origin": "*"
-      //   },
-      // }).then(handleFetchJSONResponse).then((val) => console.log(val)).catch(() => console.log("error"))
+      return fetch("https://api.index-space.org/api/pals", {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }).then(handleFetchJSONResponse)
     },
   };
 

--- a/theme/scripts/patronSlider.ts
+++ b/theme/scripts/patronSlider.ts
@@ -82,6 +82,7 @@ export default (function () {
         }
       );
 
+      // Selectors for copywriting elements.
       const handle = document.querySelector(PatronSlider.SELECTORS.handle);
       const patronTierLink = document.querySelector(
         PatronSlider.SELECTORS.patronTierLink
@@ -93,14 +94,11 @@ export default (function () {
         PatronSlider.SELECTORS.patronTierName
       );
 
-      const allPatrons = await PatronSlider.fetchPatrons();
-
-      PatronSlider.initializeCopy({
+      await PatronSlider.initializeCopy({
         handle,
         patronTierLink,
         tierCopywriting,
         patronTierName,
-        allPatrons
       });
 
       PatronSlider.bindEventListeners({
@@ -111,12 +109,14 @@ export default (function () {
       });
     },
 
-    initializeCopy({
+    /**
+     * Initialize copywriting elements.
+     */
+    async initializeCopy({
       handle,
       patronTierLink,
       tierCopywriting,
       patronTierName,
-      allPatrons
     }) {
       // Used to set the content of our slider handle
       handle.setAttribute("data-before", `$${PatronSlider.START_VALUE}`);
@@ -133,9 +133,6 @@ export default (function () {
 
       patronTierName.textContent =
         PatronSlider.PATRON_TIERS[PatronSlider.START_VALUE].name;
-
-      console.log(allPatrons);
-
     },
 
     bindEventListeners({
@@ -178,15 +175,6 @@ export default (function () {
       );
       let value = Number(valueEl.getAttribute("data-value"));
       PatronSlider.SLIDER.set(value);
-    },
-
-    async fetchPatrons() {
-      return fetch("https://api.index-space.org/api/pals", {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }).then(handleFetchJSONResponse)
     },
   };
 

--- a/theme/scripts/patronSlider.ts
+++ b/theme/scripts/patronSlider.ts
@@ -1,6 +1,5 @@
 import * as rangeSlider from "nouislider";
 import getNextSibling from "./utils/getNextSibling";
-import handleFetchJSONResponse from "./utils/handleFetchJSONResponse";
 
 const TIER_PRICES = [5, 10, 15, 20, 25];
 

--- a/theme/scripts/patronSlider.ts
+++ b/theme/scripts/patronSlider.ts
@@ -1,5 +1,7 @@
 import * as rangeSlider from "nouislider";
 import getNextSibling from "./utils/getNextSibling";
+import handleFetchJSONResponse from "./utils/handleFetchJSONResponse";
+import jsonp from "./utils/jsonp";
 
 export default (function () {
   const PatronSlider = {
@@ -49,7 +51,7 @@ export default (function () {
 
     SLIDER: null,
 
-    init() {
+    init: async () => {
       // Initialize noUiSlider instance.
       PatronSlider.SLIDER = rangeSlider.create(
         document.querySelector(PatronSlider.SELECTORS.slider),
@@ -107,6 +109,12 @@ export default (function () {
         PatronSlider.PATRON_TIERS[PatronSlider.START_VALUE].name;
 
       PatronSlider.bindEventListeners();
+
+
+
+      const patrons = await PatronSlider.fetchPatrons()
+
+      console.log(patrons);
     },
 
     bindEventListeners() {
@@ -154,6 +162,26 @@ export default (function () {
       for (var i = 0; i < pips.length; i++) {
         pips[i].addEventListener("click", (e) => handlePipClick(e));
       }
+    },
+
+    async fetchPatrons() {
+
+      jsonp('https://api.index-space.org/api/pals', "c", (err, data) => {
+        if (err) {
+          console.error(err);
+          return;
+        } else {
+          console.log(data);
+        }
+      });
+
+      // return fetch("https://api.index-space.org/api/pals", {
+      //   method: "GET",
+      //   headers: {
+      //     "Content-Type": "application/json",
+      //     "Access-Control-Allow-Origin": "*"
+      //   },
+      // }).then(handleFetchJSONResponse).then((val) => console.log(val)).catch(() => console.log("error"))
     },
   };
 

--- a/theme/scripts/patronSlider.ts
+++ b/theme/scripts/patronSlider.ts
@@ -52,34 +52,34 @@ export default (function () {
     SLIDER: null,
 
     init: async () => {
+      const slider = document.querySelector(PatronSlider.SELECTORS.slider);
+      if (!slider) return;
+
       // Initialize noUiSlider instance.
-      PatronSlider.SLIDER = rangeSlider.create(
-        document.querySelector(PatronSlider.SELECTORS.slider),
-        {
-          // Start with the slider at this value.
-          start: [PatronSlider.START_VALUE],
-          // Add this many notches along the slider.
-          step: Object.keys(PatronSlider.PATRON_TIERS).length,
-          range: {
-            min: 5,
-            max: 25,
+      PatronSlider.SLIDER = rangeSlider.create(slider as HTMLElement, {
+        // Start with the slider at this value.
+        start: [PatronSlider.START_VALUE],
+        // Add this many notches along the slider.
+        step: Object.keys(PatronSlider.PATRON_TIERS).length,
+        range: {
+          min: 5,
+          max: 25,
+        },
+        // Options for notches along the slider, called "pips"
+        pips: {
+          mode: rangeSlider.PipsMode.Steps,
+          filter: (value) => {
+            // If a slider value is not in our list of values,
+            // do not render a pip for that value.
+            if (TIER_PRICES.includes(value)) {
+              return 1;
+            } else {
+              // Render a pip.
+              return -1;
+            }
           },
-          // Options for notches along the slider, called "pips"
-          pips: {
-            mode: rangeSlider.PipsMode.Steps,
-            filter: (value) => {
-              // If a slider value is not in our list of values,
-              // do not render a pip for that value.
-              if (TIER_PRICES.includes(value)) {
-                return 1;
-              } else {
-                // Render a pip.
-                return -1;
-              }
-            },
-          },
-        }
-      );
+        },
+      });
 
       // Selectors for copywriting elements.
       const handle = document.querySelector(PatronSlider.SELECTORS.handle);
@@ -161,8 +161,8 @@ export default (function () {
       });
 
       // Listen for clicks on our pips
-      pips.forEach(pip => {
-        pip.addEventListener("click", PatronSlider.handlePipClick)
+      pips.forEach((pip) => {
+        pip.addEventListener("click", PatronSlider.handlePipClick);
       });
     },
 

--- a/theme/scripts/patronsList.ts
+++ b/theme/scripts/patronsList.ts
@@ -17,7 +17,23 @@ export default (function () {
     },
 
     async initializeCopy(patronsList: Element) {
-      const allPatronsData = await PatronsList.fetchPatrons();
+      let allPatronsData = await PatronsList.fetchPatrons();
+
+      allPatronsData = [
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+        ...allPatronsData,
+      ];
 
       allPatronsData.map(({ name }) => {
         const element = document.createElement("li");
@@ -34,7 +50,7 @@ export default (function () {
 
     async fetchPatrons() {
       return fetch(
-        "https://cors-anywhere.herokuapp.com/https://api.index-space.org/api/pals",
+        "https://cors-anywhere-devin.herokuapp.com/https://api.index-space.org/api/pals",
         {
           method: "GET",
           headers: {

--- a/theme/scripts/patronsList.ts
+++ b/theme/scripts/patronsList.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/browser";
 import handleFetchJSONResponse from "./utils/handleFetchJSONResponse";
 
 export default (function () {
@@ -28,12 +29,17 @@ export default (function () {
     },
 
     async fetchPatrons() {
-      return fetch("https://api.index-space.org/api/pals", {
+      return fetch("https://api.index-space.org/api/pal", {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
         },
-      }).then(handleFetchJSONResponse);
+      })
+        .then(handleFetchJSONResponse)
+        .catch((err) => {
+          Sentry.captureException(err);
+          return [];
+        });
     },
 
     /**

--- a/theme/scripts/patronsList.ts
+++ b/theme/scripts/patronsList.ts
@@ -1,0 +1,55 @@
+import handleFetchJSONResponse from "./utils/handleFetchJSONResponse";
+
+export default (function () {
+  const PatronsList = {
+    SELECTORS: {
+      patronsList: "[data-patrons-list]",
+    },
+
+    init: async () => {
+      await PatronsList.initializeCopy();
+    },
+
+    async initializeCopy() {
+      const allPatronsData = await PatronsList.fetchPatrons();
+
+      const patronsList = document.querySelector(
+        PatronsList.SELECTORS.patronsList
+      );
+
+      // Map patrons data and render the list item template for each.
+      patronsList.innerHTML = allPatronsData.map(PatronsList.renderPatronListItem).join('');
+    },
+
+    async fetchPatrons() {
+      return fetch("https://api.index-space.org/api/pals", {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }).then(handleFetchJSONResponse)
+    },
+
+    /**
+     * Render a single patron list item.
+     * Here we are using a template literal. This is a great way to create
+     * HTML templates without the complexity of the shadow DOM.
+     */
+    renderPatronListItem({ name, tier, badge }) {
+      return `<li class="AllPatrons__ListItem">
+        <div class="AllPatrons__ListItem__inner relative flex items-center py1_25 md:py_75 xs:pr0">
+          <div class="flex mr1_25 md:mr2_5 z-1">
+            <!-- <img class="AllPatrons__ListItem__image fit-contain w100 h100 radius-sm" sizes="(min-width: 56.25rem) 64w, 55w" srcset="{{img_src_55w}} 55w, {{img_src_64w}} 64w" src="{{ img_src_55w }}" alt="{{ image_alt }}"/> -->
+            <div class="AllPatrons__ListItem__image fit-contain w100 h100 radius-sm"></div>
+          </div>
+          <div class="flex flex-col md:flex-row items-center justify-between col-12 z-1">
+            <span class="AllPatrons__ListItem__body sans-light-sm sans-serif mb_625 md:mb0 col-12 md:col-6">${name}</span>
+            <span class="sans-xs uppercase sans-serif md:pl2 md:pt_2125 col-12 md:col-6 flex flex-col md:items-end">${tier}</span>
+          </div>
+        </div>
+      </li>`
+    }
+  };
+
+  PatronsList.init();
+})();

--- a/theme/scripts/patronsList.ts
+++ b/theme/scripts/patronsList.ts
@@ -7,22 +7,29 @@ export default (function () {
     },
 
     init: async () => {
-      await PatronsList.initializeCopy();
-    },
-
-    async initializeCopy() {
-      const allPatronsData = await PatronsList.fetchPatrons();
-
-      console.log(allPatronsData);
-
       const patronsList = document.querySelector(
         PatronsList.SELECTORS.patronsList
       );
 
+      if (!patronsList) return;
+
+      await PatronsList.initializeCopy(patronsList);
+    },
+
+    async initializeCopy(patronsList: Element) {
+      const allPatronsData = await PatronsList.fetchPatrons();
+
+      allPatronsData.map(({ name }) => {
+        const element = document.createElement("li");
+        element.className = "ListItem sans-light-sm sans-serif";
+        element.innerText = name;
+        patronsList.appendChild(element);
+      });
+
       // Map patrons data and render the list item template for each.
-      patronsList.innerHTML = allPatronsData
-        .map(PatronsList.renderPatronListItem)
-        .join("");
+      // patronsList.innerHTML = allPatronsData
+      //   .map(PatronsList.renderPatronListItem)
+      //   .join("");
     },
 
     async fetchPatrons() {
@@ -43,10 +50,10 @@ export default (function () {
      * HTML templates without the complexity of the shadow DOM.
      */
     renderPatronListItem({ name }) {
-      return `
-        <li class="ListItem sans-light-sm sans-serif">
-          ${name}
-        </li>`;
+      const element = document.createElement("li");
+      element.className = "ListItem sans-light-sm sans-serif";
+      element.innerText = name;
+      return element;
     },
   };
 

--- a/theme/scripts/patronsList.ts
+++ b/theme/scripts/patronsList.ts
@@ -19,45 +19,21 @@ export default (function () {
     async initializeCopy(patronsList: Element) {
       let allPatronsData = await PatronsList.fetchPatrons();
 
-      allPatronsData = [
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-        ...allPatronsData,
-      ];
-
       allPatronsData.map(({ name }) => {
         const element = document.createElement("li");
         element.className = "ListItem sans-light-sm sans-serif";
         element.innerText = name;
         patronsList.appendChild(element);
       });
-
-      // Map patrons data and render the list item template for each.
-      // patronsList.innerHTML = allPatronsData
-      //   .map(PatronsList.renderPatronListItem)
-      //   .join("");
     },
 
     async fetchPatrons() {
-      return fetch(
-        "https://cors-anywhere-devin.herokuapp.com/https://api.index-space.org/api/pals",
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }
-      ).then(handleFetchJSONResponse);
+      return fetch("https://api.index-space.org/api/pals", {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }).then(handleFetchJSONResponse);
     },
 
     /**

--- a/theme/scripts/patronsList.ts
+++ b/theme/scripts/patronsList.ts
@@ -20,6 +20,8 @@ export default (function () {
     async initializeCopy(patronsList: Element) {
       let allPatronsData = await PatronsList.fetchPatrons();
 
+      if (!allPatronsData.length) return;
+
       allPatronsData.map(({ name }) => {
         const element = document.createElement("li");
         element.className = "ListItem sans-light-sm sans-serif";

--- a/theme/scripts/patronsList.ts
+++ b/theme/scripts/patronsList.ts
@@ -13,21 +13,28 @@ export default (function () {
     async initializeCopy() {
       const allPatronsData = await PatronsList.fetchPatrons();
 
+      console.log(allPatronsData);
+
       const patronsList = document.querySelector(
         PatronsList.SELECTORS.patronsList
       );
 
       // Map patrons data and render the list item template for each.
-      patronsList.innerHTML = allPatronsData.map(PatronsList.renderPatronListItem).join('');
+      patronsList.innerHTML = allPatronsData
+        .map(PatronsList.renderPatronListItem)
+        .join("");
     },
 
     async fetchPatrons() {
-      return fetch("https://api.index-space.org/api/pals", {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }).then(handleFetchJSONResponse)
+      return fetch(
+        "https://cors-anywhere.herokuapp.com/https://api.index-space.org/api/pals",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      ).then(handleFetchJSONResponse);
     },
 
     /**
@@ -35,20 +42,12 @@ export default (function () {
      * Here we are using a template literal. This is a great way to create
      * HTML templates without the complexity of the shadow DOM.
      */
-    renderPatronListItem({ name, tier, badge }) {
-      return `<li class="AllPatrons__ListItem">
-        <div class="AllPatrons__ListItem__inner relative flex items-center py1_25 md:py_75 xs:pr0">
-          <div class="flex mr1_25 md:mr2_5 z-1">
-            <!-- <img class="AllPatrons__ListItem__image fit-contain w100 h100 radius-sm" sizes="(min-width: 56.25rem) 64w, 55w" srcset="{{img_src_55w}} 55w, {{img_src_64w}} 64w" src="{{ img_src_55w }}" alt="{{ image_alt }}"/> -->
-            <div class="AllPatrons__ListItem__image fit-contain w100 h100 radius-sm"></div>
-          </div>
-          <div class="flex flex-col md:flex-row items-center justify-between col-12 z-1">
-            <span class="AllPatrons__ListItem__body sans-light-sm sans-serif mb_625 md:mb0 col-12 md:col-6">${name}</span>
-            <span class="sans-xs uppercase sans-serif md:pl2 md:pt_2125 col-12 md:col-6 flex flex-col md:items-end">${tier}</span>
-          </div>
-        </div>
-      </li>`
-    }
+    renderPatronListItem({ name }) {
+      return `
+        <li class="ListItem sans-light-sm sans-serif">
+          ${name}
+        </li>`;
+    },
   };
 
   PatronsList.init();

--- a/theme/scripts/patronsList.ts
+++ b/theme/scripts/patronsList.ts
@@ -29,7 +29,7 @@ export default (function () {
     },
 
     async fetchPatrons() {
-      return fetch("https://api.index-space.org/api/pal", {
+      return fetch("https://api.index-space.org/api/pals", {
         method: "GET",
         headers: {
           "Content-Type": "application/json",

--- a/theme/snippets/patrons-list.liquid
+++ b/theme/snippets/patrons-list.liquid
@@ -1,1 +1,1 @@
-<ul class="AllPatrons list-style-none mb2" data-patrons-list></ul>
+<ul class="AllPatrons mb2 list-style-none" data-patrons-list></ul>

--- a/theme/snippets/patrons-list.liquid
+++ b/theme/snippets/patrons-list.liquid
@@ -1,0 +1,1 @@
+<ul class="AllPatrons list-style-none mb2" data-patrons-list></ul>

--- a/theme/snippets/patrons-list.liquid
+++ b/theme/snippets/patrons-list.liquid
@@ -1,1 +1,1 @@
-<ul class="AllPatrons mb2 list-style-none" data-patrons-list></ul>
+<ul class="AllPatrons mb4 list-style-none" data-patrons-list></ul>

--- a/theme/styles/_snippets.scss
+++ b/theme/styles/_snippets.scss
@@ -24,3 +24,4 @@
 @import 'snippets/add-to-cart-container';
 @import 'snippets/product-date';
 @import 'snippets/patron-slider';
+@import 'snippets/patrons-list';

--- a/theme/styles/snippets/image-caption-module.scss
+++ b/theme/styles/snippets/image-caption-module.scss
@@ -1,12 +1,11 @@
 .ImageCaptionModule {
   &--style-full-bleed {
-    left: 50%;
-    margin-left: -50%;
-    margin-right: -50%;
-    max-width: 100vw;
+    width: 100vw;
     position: relative;
+    left: 50%;
     right: 50%;
-    width: 100%;
+    margin-left: -50vw;
+    margin-right: -50vw;
   }
 
   &__images {
@@ -16,20 +15,20 @@
       div:not(:last-of-type) {
         margin-right: 0.6875rem;
 
-        @include media('md-up') {
+        @include media("md-up") {
           margin-right: 1.9375rem;
         }
       }
 
-      @include media('xs-up') {
+      @include media("xs-up") {
         max-height: 15rem;
       }
 
-      @include media('md-up') {
+      @include media("md-up") {
         max-height: 20rem;
       }
 
-      @include media('lg-up') {
+      @include media("lg-up") {
         max-height: 30rem;
       }
     }

--- a/theme/styles/snippets/patron-slider.scss
+++ b/theme/styles/snippets/patron-slider.scss
@@ -74,8 +74,8 @@ $pips-container-width: (
 
   &__PatronLink {
     &:hover {
-      background-color: color('white');
-      color: color('black');
+      background-color: color("white");
+      color: color("black");
     }
   }
 }

--- a/theme/styles/snippets/patron-slider.scss
+++ b/theme/styles/snippets/patron-slider.scss
@@ -224,36 +224,3 @@ $pips-container-width: (
     }
   }
 }
-
-
-.AllPatrons {
-  &__ListItem {
-    &__inner {
-      border-bottom: solid 1px color('black');
-      margin-left: $margin-offset-sm;
-      margin-right: $margin-offset-sm;
-
-      @include media('md-up') {
-        margin-left: $margin-offset-md;
-        margin-right: $margin-offset-md;
-      }
-    }
-
-    &:first-of-type {
-      &__inner {
-        border-top: solid 1px color('black');
-      }
-    }
-
-    &__image {
-      width: 3.4375rem;
-      height: 3.4375rem;
-      background-color: #2dac61;
-
-      @include media('md-up') {
-        width: 4rem;
-        height: 4rem;
-      }
-    }
-  }
-}

--- a/theme/styles/snippets/patron-slider.scss
+++ b/theme/styles/snippets/patron-slider.scss
@@ -224,3 +224,36 @@ $pips-container-width: (
     }
   }
 }
+
+
+.AllPatrons {
+  &__ListItem {
+    &__inner {
+      border-bottom: solid 1px color('black');
+      margin-left: $margin-offset-sm;
+      margin-right: $margin-offset-sm;
+
+      @include media('md-up') {
+        margin-left: $margin-offset-md;
+        margin-right: $margin-offset-md;
+      }
+    }
+
+    &:first-of-type {
+      &__inner {
+        border-top: solid 1px color('black');
+      }
+    }
+
+    &__image {
+      width: 3.4375rem;
+      height: 3.4375rem;
+      background-color: #2dac61;
+
+      @include media('md-up') {
+        width: 4rem;
+        height: 4rem;
+      }
+    }
+  }
+}

--- a/theme/styles/snippets/patrons-list.scss
+++ b/theme/styles/snippets/patrons-list.scss
@@ -1,25 +1,39 @@
 .AllPatrons {
-  &__ListItem {
-    &__inner {
-      border-bottom: solid 1px color('black');
-      margin-left: $margin-offset-sm;
-      margin-right: $margin-offset-sm;
+  max-height: 600px;
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: minmax(min-content, max-content);
+  grid-gap: 1rem;
+  text-align: center;
 
-      @include media('md-up') {
-        margin-left: $margin-offset-md;
-        margin-right: $margin-offset-md;
-      }
-    }
+  @include media("md-up") {
+    max-width: 65rem;
+    width: 75%;
+    margin: 0 auto;
+  }
 
-    &__image {
-      width: 3.4375rem;
-      height: 3.4375rem;
-      background-color: #2dac61;
+  &:after {
+    content: "";
+    position: absolute;
+    z-index: 1;
+    bottom: -1rem;
+    left: 0;
+    pointer-events: none;
+    background-image: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0),
+      rgba(255, 255, 255, 1) 90%
+    );
+    width: 100%;
+    height: 4em;
+  }
 
-      @include media('md-up') {
-        width: 4rem;
-        height: 4rem;
-      }
-    }
+  .ListItem {
+    line-height: normal;
+    width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow-x: hidden;
   }
 }

--- a/theme/styles/snippets/patrons-list.scss
+++ b/theme/styles/snippets/patrons-list.scss
@@ -10,7 +10,8 @@
   @include media("md-up") {
     max-width: 65rem;
     width: 75%;
-    margin: 0 auto;
+    margin-left: auto;
+    margin-right: auto;
     grid-template-columns: repeat(3, 1fr);
   }
 

--- a/theme/styles/snippets/patrons-list.scss
+++ b/theme/styles/snippets/patrons-list.scss
@@ -1,0 +1,25 @@
+.AllPatrons {
+  &__ListItem {
+    &__inner {
+      border-bottom: solid 1px color('black');
+      margin-left: $margin-offset-sm;
+      margin-right: $margin-offset-sm;
+
+      @include media('md-up') {
+        margin-left: $margin-offset-md;
+        margin-right: $margin-offset-md;
+      }
+    }
+
+    &__image {
+      width: 3.4375rem;
+      height: 3.4375rem;
+      background-color: #2dac61;
+
+      @include media('md-up') {
+        width: 4rem;
+        height: 4rem;
+      }
+    }
+  }
+}

--- a/theme/styles/snippets/patrons-list.scss
+++ b/theme/styles/snippets/patrons-list.scss
@@ -1,16 +1,17 @@
 .AllPatrons {
   max-height: 600px;
+  overflow-y: hidden;
   position: relative;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   grid-template-rows: minmax(min-content, max-content);
   grid-gap: 1rem;
-  text-align: center;
 
   @include media("md-up") {
     max-width: 65rem;
     width: 75%;
     margin: 0 auto;
+    grid-template-columns: repeat(3, 1fr);
   }
 
   &:after {
@@ -35,5 +36,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow-x: hidden;
+    text-transform: uppercase;
   }
 }

--- a/theme/styles/snippets/patrons-list.scss
+++ b/theme/styles/snippets/patrons-list.scss
@@ -5,14 +5,14 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: minmax(min-content, max-content);
-  grid-gap: 1rem;
+  grid-gap: 2rem;
 
   @include media("md-up") {
     max-width: 65rem;
     width: 75%;
     margin-left: auto;
     margin-right: auto;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
   }
 
   &:after {
@@ -38,5 +38,6 @@
     white-space: nowrap;
     overflow-x: hidden;
     text-transform: uppercase;
+    text-align: left;
   }
 }

--- a/theme/templates/page.patrons.liquid
+++ b/theme/templates/page.patrons.liquid
@@ -17,5 +17,6 @@
           {% render 'page-title' title: page.title %}
       {% endcase %}
     {% endfor %}
+    <ul class="AllPatrons list-style-none" data-patrons-list></ul>
   </div>
 </div>

--- a/theme/templates/page.patrons.liquid
+++ b/theme/templates/page.patrons.liquid
@@ -15,8 +15,9 @@
           {% render 'patron-slider' %}
         {% when 'patrons_page_custom_title' %}
           {% render 'page-title' title: page.title %}
+        {% when 'patrons_page_patrons_list' %}
+          {% render 'patrons-list' %}
       {% endcase %}
     {% endfor %}
-    <ul class="AllPatrons list-style-none" data-patrons-list></ul>
   </div>
 </div>


### PR DESCRIPTION
### Description

This PR closes #208. It adds functionality to render Patreon subscribers on the new Join page via an API endpoint written by @hhff (accessible [here](https://api.index-space.org/api/pals)).

_Note: This has been branched off #206 as it builds on that code. Once that PR is merged, I will set this PR to merge into `main` instead of `feature/206-patron-slider`._

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Update to an existing feature

### Motivation for PR

Initially I considered using [HTML content templates and slots](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots) to render the required markup. However, this required me to use the shadow DOM to insert custom elements like `<patron-line-item>`, which I think is not optimal because you cannot inspect the children to debug CSS etc.

So I decided instead to simply use a JS template literal. This sacrifices co-location of our markup for a cleaner development experience on the JS side, and easier CSS debugging in-browser.

### How Has This Been Tested?

Tested in Safari and Firefox.

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
