### PR TITLE
Add accentuate metafield for custom share card images on page templates

### DIFF
--- a/theme/snippets/meta.liquid
+++ b/theme/snippets/meta.liquid
@@ -37,7 +37,7 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="{{ 'seo.default_title' | t }} — {{ page.title | escape }}">
   <meta name="twitter:description" content="{{ page_description | escape }}">
-  {% if page_share_card_image %}
+  {% if page_share_card_image.src %}
     <meta property="og:image" content="{{ page_share_card_image.src }}">
   {% else %}
     <meta property="og:image" content="https:{{ 'index-share-card.jpg' |  asset_url }}">

--- a/theme/snippets/meta.liquid
+++ b/theme/snippets/meta.liquid
@@ -2,6 +2,7 @@
 {% assign featured_image = current_variant.featured_image | default: product.featured_image %}
 {% assign product_description = product.metafields.accentuate.product_description_seo %}
 {% assign page_description = page.metafields.accentuate.page_description_seo %}
+{% assign page_share_card_image = page.metafields.accentuate.share_card_image | first %}
 {% assign collection_description = collection.metafields.accentuate.collection_description_seo %}
 
 <meta charset="utf-8">
@@ -36,7 +37,12 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="{{ 'seo.default_title' | t }} — {{ page.title | escape }}">
   <meta name="twitter:description" content="{{ page_description | escape }}">
-  <meta property="og:image" content="https:{{ 'index-share-card.jpg' |  asset_url }}">
+  {% if page_share_card_image %}
+    <meta property="og:image" content="{{ page_share_card_image.src }}">
+  {% else %}
+    <meta property="og:image" content="https:{{ 'index-share-card.jpg' |  asset_url }}">
+  {% endif %}
+
 
 {% else %}
   <title>{{ 'seo.default_title' | t }} — {{ page.title | escape }}</title>


### PR DESCRIPTION
### Description

- Adds accentuate metafield for custom share card images on pages where `template contains 'page'`. Eg. on any Liquid templates named `page.page-name.liquid`.
  - This does not effect non-top-level pages such as products, collections, blog posts, etc.

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Update to an existing feature

### Motivation for PR

Enable share card images for the new Join page launching tomorrow.

### How Has This Been Tested?

Tested with the Join page

### Applicable screenshots:

<img width="505" alt="image" src="https://user-images.githubusercontent.com/1934813/149244891-dc3f34a6-816c-45de-8bad-9a257dc0c828.png">
