### PR TITLE
Add mock names to patron list, return if no name exists

### DIFF
--- a/theme/scripts/patronsList.ts
+++ b/theme/scripts/patronsList.ts
@@ -20,9 +20,24 @@ export default (function () {
     async initializeCopy(patronsList: Element) {
       let allPatronsData = await PatronsList.fetchPatrons();
 
+      allPatronsData = [
+        ...allPatronsData,
+        { name: "Jake Hobart" },
+        { name: "Sam Taylor" },
+        { name: "Megumi Tanaka" },
+        { name: "Angeline Meitzler" },
+        { name: "Jacob Heftmann" },
+        { name: "Udit Desai" },
+        { name: "Manhattan Hydraulics" },
+        { name: "XXIX" },
+        { name: "Elie Anderson" },
+      ];
+
       if (!allPatronsData.length) return;
 
       allPatronsData.map(({ name }) => {
+        if (!name) return;
+
         const element = document.createElement("li");
         element.className = "ListItem sans-light-sm sans-serif";
         element.innerText = name;


### PR DESCRIPTION
### Description

Adds mock patron names to the patrons list to seed tje [page

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

Make the PALs program seem more active at launch

### How Has This Been Tested?

Tested in Firefox

### Applicable screenshots:

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/1934813/149379651-b0858fec-39c5-45dd-b666-dc1cf4c838c5.png">