### PR TITLE
💅 PALs Polish

### DIFF
--- a/theme/snippets/image-caption-module.liquid
+++ b/theme/snippets/image-caption-module.liquid
@@ -1,6 +1,6 @@
 {% comment %}
-With Accentuate.io, even if only one image is uploaded, the metafield
-is always an array.
+With Accentuate.io, even if only one image is uploaded, the metafield is always
+an array. You should use the `first` filter if it's a single image input.
 {% endcomment %}
 {% assign image_module_images = shop.metafields.globals['image_module_image'][module.index] %}
 {% assign image_module_first_image = shop.metafields.globals['image_module_image'][module.index].first %}
@@ -17,7 +17,12 @@ is always an array.
     {% if variant == 'centered' %}
       col-12 md:col-6 mxauto py5 md:py10
     {% elsif variant == 'full-width' %}
-      col-12 py3
+      col-12
+      {% if rounded %}
+        py0 ImageCaptionModule--style-full-width-rounded
+      {% else %}
+        py3
+      {% endif %}
     {% elsif variant == 'left' %}
       sm:flex-row py3 col-12
     {% elsif variant == 'full-bleed' %}

--- a/theme/snippets/image-caption-module.liquid
+++ b/theme/snippets/image-caption-module.liquid
@@ -19,7 +19,7 @@ an array. You should use the `first` filter if it's a single image input.
     {% elsif variant == 'full-width' %}
       col-12
       {% if rounded %}
-        py0 ImageCaptionModule--style-full-width-rounded
+        pt0 pb3 ImageCaptionModule--style-full-width-rounded
       {% else %}
         py3
       {% endif %}

--- a/theme/styles/snippets/image-caption-module.scss
+++ b/theme/styles/snippets/image-caption-module.scss
@@ -12,7 +12,7 @@
     @include media("md-up") {
       margin-top: $site-padding-x-desktop;
       margin-bottom: $site-padding-x-desktop;
-      // padding-bottom: $site-padding-x-desktop;
+      padding-bottom: 3rem;
     }
   }
 

--- a/theme/styles/snippets/image-caption-module.scss
+++ b/theme/styles/snippets/image-caption-module.scss
@@ -1,4 +1,21 @@
 .ImageCaptionModule {
+  &--style-full-width-rounded {
+    margin-top: $site-padding-x-mobile;
+    margin-bottom: $site-padding-x-mobile;
+    padding-bottom: $site-padding-x-mobile;
+
+    img {
+      border-radius: radius("sm");
+      overflow: hidden;
+    }
+
+    @include media("md-up") {
+      margin-top: $site-padding-x-desktop;
+      margin-bottom: $site-padding-x-desktop;
+      // padding-bottom: $site-padding-x-desktop;
+    }
+  }
+
   // Break out of site padding on the container.
   &--style-full-bleed {
     margin-left: -$site-padding-x-mobile;

--- a/theme/templates/page.patrons.liquid
+++ b/theme/templates/page.patrons.liquid
@@ -10,7 +10,7 @@
         {% when 'page_markdown' %}
           {% render 'markdown' variant: variant markdown: shop.metafields.globals['page_markdown'][module.index].html classes: 'md:my2' %}
         {% when 'image_module' %}
-          {% render 'image-caption-module' module: module styling: variant %}
+          {% render 'image-caption-module' module: module styling: variant rounded: true %}
         {% when 'patreon_pricing_module' %}
           {% render 'patron-slider' title: page.metafields.accentuate.patrons_slider_h1 button_text: page.metafields.accentuate.patrons_slider_button_text %}
         {% when 'patrons_page_custom_title' %}


### PR DESCRIPTION
### Description

Adds `.ImageCaptionModule--style-full-width-rounded` so create rounded corners on the image. It only supports the `full-width` variant.

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

This was in the Figma and we used to have the borders rounded. I could have just used an image but then the corners would not scale the same as the slider's corners.

### How Has This Been Tested?

Tested in firefox and safari

### Applicable screenshots:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/1934813/149608241-7ba7b94a-8b77-49b4-941d-9068c34cb23e.png">
