### PR TITLE
temporarily reverse patron list from API

### DIFF
--- a/theme/scripts/patronsList.ts
+++ b/theme/scripts/patronsList.ts
@@ -20,6 +20,10 @@ export default (function () {
     async initializeCopy(patronsList: Element) {
       let allPatronsData = await PatronsList.fetchPatrons();
 
+      // TODO: Remove this when Hugh can adjust the API to return
+      // Patrons in reverse-chron order.
+      allPatronsData = allPatronsData.reverse();
+
       allPatronsData = [
         ...allPatronsData,
         { name: "Jake Hobart" },


### PR DESCRIPTION
### Description

temporarily reverse the order of data returned from the Patrons API endpoint.

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

Display the most recent patrons first until @hhff can do this on the API side in ~2 weeks.

### How Has This Been Tested?

tested in Firefox with current patron list

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

Revert this once it is handled by the API
