### PR TITLE
add reset password redirect script

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 14.0.0
+nodejs 14.0.0 nodejs ref:v14.18.0

--- a/theme/scripts/accountResetRedirect.ts
+++ b/theme/scripts/accountResetRedirect.ts
@@ -1,20 +1,14 @@
 // URL of members reset password page
-const MEMBERS_RESET_PASSWORD_URL = "https://members.index-space.org/reset-password";
+const MEMBERS_RESET_PASSWORD_URL = "https://members.index-space.org";
 // A typical shopify password reset url is like this:
 // https://index-space.org/account/reset/[id]/[token]
 const SHOPIFY_RESET_PASSWORD_PATHNAME = "/account/reset";
-const ID_PATHNAME_POSITION = 3;
-const TOKEN_PATHNAME_POSITION = 4;
 
 export default (function () {
   const AccountResetRedirect = {
     init() {
       if (window.location.pathname.includes(SHOPIFY_RESET_PASSWORD_PATHNAME)) {
-        const pathList = window.location.pathname.split('/');
-        const id = pathList[ID_PATHNAME_POSITION];
-        const token = pathList[TOKEN_PATHNAME_POSITION];
-
-        const redirectUrl = `${MEMBERS_RESET_PASSWORD_URL}?id=${id}&token=${token}`;
+        const redirectUrl = `${MEMBERS_RESET_PASSWORD_URL}${window.location.pathname}`;
         window.location.replace(redirectUrl)
       }
     },

--- a/theme/scripts/accountResetRedirect.ts
+++ b/theme/scripts/accountResetRedirect.ts
@@ -1,0 +1,24 @@
+// URL of members reset password page
+const MEMBERS_RESET_PASSWORD_URL = "https://members.index-space.org/reset-password";
+// A typical shopify password reset url is like this:
+// https://index-space.org/account/reset/[id]/[token]
+const SHOPIFY_RESET_PASSWORD_PATHNAME = "/account/reset";
+const ID_PATHNAME_POSITION = 3;
+const TOKEN_PATHNAME_POSITION = 4;
+
+export default (function () {
+  const AccountResetRedirect = {
+    init() {
+      if (window.location.pathname.includes(SHOPIFY_RESET_PASSWORD_PATHNAME)) {
+        const pathList = window.location.pathname.split('/');
+        const id = pathList[ID_PATHNAME_POSITION];
+        const token = pathList[TOKEN_PATHNAME_POSITION];
+
+        const redirectUrl = `${MEMBERS_RESET_PASSWORD_URL}?id=${id}&token=${token}`;
+        window.location.replace(redirectUrl)
+      }
+    },
+  };
+
+  AccountResetRedirect.init();
+})();

--- a/theme/scripts/index.ts
+++ b/theme/scripts/index.ts
@@ -29,3 +29,4 @@ import "./fadeIn";
 import "./magicMouse";
 import "./patronSlider";
 import "./patronsList";
+import "./accountResetRedirect";


### PR DESCRIPTION
**Loom vid:** https://www.loom.com/share/cb08aa52603e4dcbaaacb7ba692d5f21

### Description

This PR adds a script that adds a redirect from the `/account/reset` route of the Shopify theme to the `https://members.index-space.org/reset-password` page. 

This is from an issue within the `index-space` repo: https://github.com/sanctuarycomputer/index-space/issues/175

Along with this added code, Index's customer accounts setting was changed to "accounts are optional" from "accounts are disabled". Note that this change changes the checkout page to add a little note to sign in if you can have an account which is quite minor:

<img width="1329" alt="Screen Shot 2022-01-19 at 6 28 37 PM" src="https://user-images.githubusercontent.com/14059589/150239842-dd432f49-0732-4009-a592-021fd31b454f.png">

However, if someone does end up clicking that, it takes them to `/account/login` route of the Shopify theme which is a blank page.

### Type(s) of changes

- [x] New feature

### Motivation for PR

https://github.com/sanctuarycomputer/index-space/issues/175

### How Has This Been Tested?

Preview URL: https://98hh5lt1jbnr1lix-52674822324.shopifypreview.com/
Members app URL: https://members.index-space.org/auth

Tested the flow using the live member's app and a reset password email I received that links to the `/account/reset` route and the redirect worked.

### Follow-up PR

Maybe worth redirecting the `/account/login` route too? Or just adding a message on the page saying "Coming soon"?
