### PR TITLE
allow collections to show more than 50 products

### DIFF
--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -2,7 +2,11 @@
 
 <h1 class="safe-visibility-hidden">{{ collection.title }}</h1>
 <div class="grid {% if show_featured_product %} grid--style-first-cell-enlarged  {% endif %}">
-  {% for product in collection.products %}
-    {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}  
-  {% endfor %}
+  <!-- this liquid logic allows us to show more than 50 products in a collection page without pagination -->
+  <!-- 1000 is an arbitrary large number used so we won't run into a limit in the future -->
+  {% paginate collection.products by 1000 %}
+    {% for product in collection.products %}
+      {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}  
+    {% endfor %}
+  {% endpaginate %}
 </div>


### PR DESCRIPTION
### Description

This PR adds liquid pagination logic to render more than 50 products on a collection page. The limit is set to 1000 right now to ensure we won't run into a limit like this in the future.

### Type(s) of changes

- [x] Update to an existing feature

### Motivation for PR

Elie asked for this on Twist: https://twist.com/a/133876/ch/376069/t/2382693/c/74007166

### How Has This Been Tested?

Tested through this preview on the books collection which currently has more than 50 products: https://l8ez4qdi31ruyobl-52674822324.shopifypreview.com