### PR TITLE
setup fields in accentuate and add them to logic

### DIFF
--- a/theme/snippets/add-to-cart-container.liquid
+++ b/theme/snippets/add-to-cart-container.liquid
@@ -27,7 +27,7 @@
     {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
   {% endif %}
 
-  {% if product.metafields.accentuate.starts_at %}
+  {% if product.metafields.accentuate.starts_at and product.metafields.accentuate.ends_at %}
     {% assign starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
     {% assign ends_at = product.metafields.accentuate.ends_at | date: '%s' %}
   {% endif %}

--- a/theme/snippets/add-to-cart-container.liquid
+++ b/theme/snippets/add-to-cart-container.liquid
@@ -11,7 +11,7 @@
 {% assign button_disabled = false %}
 
 <!-- Assign label and disabled state to add to cart button -->
-{% if lowercase_product_type == "event" or lowercase_product_type == "course" %}
+{% if lowercase_product_type == "event" or lowercase_product_type == "course" or lowercase_product_type == "workshop" %}
 
   <!-- For bookings products -->
   {% assign current_variant = product.selected_or_first_available_variant %}
@@ -25,6 +25,11 @@
   {% elsif lowercase_product_type == "event" %}
     {% assign starts_at = bookings_metafields.starts_at | date: '%s' %}
     {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
+  {% endif %}
+
+  {% if product.metafields.accentuate.starts_at %}
+    {% assign starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
+    {% assign ends_at = product.metafields.accentuate.ends_at | date: '%s' %}
   {% endif %}
 
   {% if todays_date > ends_at %}

--- a/theme/snippets/product-grid-item.liquid
+++ b/theme/snippets/product-grid-item.liquid
@@ -24,7 +24,7 @@
         <div class="flex justify-between">
           <span class="ProductGridItem__title">{{current_product.title}}</span>
           {% assign lowercase_product_type = current_product_type | downcase %}
-          {% if lowercase_product_type == "course" or lowercase_product_type == "event" %}
+          {% if lowercase_product_type == "course" or lowercase_product_type == "event" or lowercase_product_type == "workshop" %}
             {% render 'product-registration-state' product: current_product, product_type: lowercase_product_type %}
           {% else %}
             <span class="ProductGridItem__price text-right pl1_5 uppercase">{{current_product.price | money_without_trailing_zeros }}</span>

--- a/theme/snippets/product-registration-state.liquid
+++ b/theme/snippets/product-registration-state.liquid
@@ -17,7 +17,7 @@
   {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
 {% endif %}
 
-{% if product.metafields.accentuate.starts_at %}
+{% if product.metafields.accentuate.starts_at and product.metafields.accentuate.end_at %}
   {% assign starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
   {% assign ends_at = product.metafields.accentuate.ends_at | date: '%s' %}
 {% endif %}

--- a/theme/snippets/product-registration-state.liquid
+++ b/theme/snippets/product-registration-state.liquid
@@ -17,6 +17,11 @@
   {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
 {% endif %}
 
+{% if product.metafields.accentuate.starts_at %}
+  {% assign starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
+  {% assign ends_at = product.metafields.accentuate.ends_at | date: '%s' %}
+{% endif %}
+
 {% if todays_date > ends_at %}
   {% assign registration_state = 'snippets.product_registration_state.past' | t %}
 {% elsif todays_date > starts_at %}


### PR DESCRIPTION
### Description

This PR adds date fields for products in Accentuate named `starts_at` and `ends_at` that signify the start date and time plus end date and time for events, courses, and workshops.

The flow and logic is the same as it used to be with bookings dates so I only needed to add code to retrieve the dates from accentuate metafields. The same `liquid` variables used to store the bookings dates are overrided with the dates from accentuate if they exist. This means Accentuate will have the 'final say', but bookings data will still be used for old events.

The date + time field in Accentuate uses UTC time so I added a description letting editors to know to adjust their times to UTC when entering them:
<img width="674" alt="Screen Shot 2022-03-01 at 2 04 13 PM" src="https://user-images.githubusercontent.com/14059589/156240423-f01b521b-cfc8-4058-a61d-f53a85b5c6ac.png">

### Type(s) of changes

- [x] Update to an existing feature

### Motivation for PR

Registration status and the add to cart button state for events/courses were controlled through looking at Bookings dates. Now that we are no longer using Bookings, we needed to add fields for dates into Accentuate so the logic and UI can remain the same.

### How Has This Been Tested?

View preview link here: https://yedq8ftbyag6rznv-52674822324.shopifypreview.com

All events/courses/workshops on the Happenings tab now show their accurate registration status. I added in dates for new/old events not using Bookings through Accentuate to test it out.

**Note:** I am not able to test out states for events/courses in the future or that are currently occurring because they would show up on the live store. However, the logic is exactly the same and I made sure that the date/time values from Accentuate and Bookings are the same as well so it will work like it used to.
