### PR TITLE
fix typo by changing end_at to ends_at

### DIFF
--- a/theme/snippets/product-registration-state.liquid
+++ b/theme/snippets/product-registration-state.liquid
@@ -17,7 +17,7 @@
   {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
 {% endif %}
 
-{% if product.metafields.accentuate.starts_at and product.metafields.accentuate.end_at %}
+{% if product.metafields.accentuate.starts_at and product.metafields.accentuate.ends_at %}
   {% assign starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
   {% assign ends_at = product.metafields.accentuate.ends_at | date: '%s' %}
 {% endif %}


### PR DESCRIPTION
### Description

There was a typo in the last PR that I found before publishing the theme. Instead of `ends_at`  in the if check, I had written `end_at`.

### Type(s) of changes

- [x] Bug fix

### How Has This Been Tested?

theme with this fix applied: https://k32rl6c2xhzvaglc-52674822324.shopifypreview.com
