### PR TITLE
adjust description to use accentuate description if fields are not empty and product type matches

### DIFF
--- a/theme/snippets/product-description.liquid
+++ b/theme/snippets/product-description.liquid
@@ -1,11 +1,18 @@
 {% assign current_variant = product.selected_or_first_available_variant %}
-{% assign is_course = false %}
+{% assign show_detailed_description = false %}
 
 {% if current_variant.metafields.bookings != blank and current_variant.metafields.bookings.bookable_type == "Course" %}
-  {% assign is_course = true %}
+  {% assign show_detailed_description = true %}
 {% endif %}
 
-{% if is_course %}
+{% assign lowercase_product_type = product.type | downcase %}
+{% if lowercase_product_type == "event" or lowercase_product_type == "course" or lowercase_product_type == "workshop" %}
+  {% if product.metafields.accentuate.title and product.metafields.accentuate.markdown %}
+    {% assign show_detailed_description = true %}
+  {% endif %}
+{% endif %}
+
+{% if show_detailed_description %}
   <div data-product-description-tabs-wrapper class="ProductDescription__tabs border-bottom-black sticky pt_5 pb_5 site-padding-x z-description flex flex-row items flex-nowrap overflow-x-auto overflow-y-hidden w100">
     {% for title in product.metafields.accentuate.title %}
       <a 


### PR DESCRIPTION
### Description

Changes the checking logic that determines which product description design to render.

**Before:** Show accentuate product description if it is a bookings product of the course type
**Now:** The above OR if the product is either a `event`, `course`, or `workshop` and the description `title` and `markdown` fields from accentuate are not empty.

### Type(s) of changes

- [x] Update to an existing feature

### Motivation for PR

Sam asked for this on Twist because we are not using Bookings on Index anymore.

### How Has This Been Tested?

Tested through a non bookings event product by adding and removing the Accentuate description to see what renders. Also ensured past bookings products still show the accentuate description and non event/course/workshop products still show the regular shopify description.

Preview link: https://movqrsx6mn4kh896-52674822324.shopifypreview.com
