### PR TITLE
Feature/add registration date fields

### DIFF
--- a/theme/locales/en.default.json
+++ b/theme/locales/en.default.json
@@ -159,6 +159,10 @@
         "aria_label": "Product is sold out",
         "text": "Sold out"
       },
+      "upcoming_btn": {
+        "aria_label": "Registration has not started yet.",
+        "text": "Upcoming"
+      },
       "quantity_spinner": {
         "label": "Quantity"
       },

--- a/theme/snippets/add-to-cart-container.liquid
+++ b/theme/snippets/add-to-cart-container.liquid
@@ -17,22 +17,20 @@
   {% assign current_variant = product.selected_or_first_available_variant %}
   {% assign bookings_metafields = current_variant.metafields.bookings %}
   {% assign todays_date = 'now' | date: '%s' %}
+  {% assign registration_starts_at = todays_date %}
 
   {% if lowercase_product_type == "course" %}
     {% assign sessions_sorted = bookings_metafields.sessions | sort: 'starts_at' %}
-    {% assign registration_starts_at = sessions_sorted.first.starts_at | date: '%s' %}
     {% assign registration_ends_at = sessions_sorted.first.starts_at | date: '%s' %}
     {% assign starts_at = sessions_sorted.first.starts_at | date: '%s' %}
     {% assign ends_at = sessions_sorted.last.ends_at | date: '%s' %}
   {% elsif lowercase_product_type == "event" %}
-    {% assign registration_starts_at = bookings_metafields.starts_at | date: '%s' %}
     {% assign registration_ends_at = bookings_metafields.starts_at | date: '%s' %}
     {% assign starts_at = bookings_metafields.starts_at | date: '%s' %}
     {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
   {% endif %}
 
   {% if product.metafields.accentuate.starts_at and product.metafields.accentuate.ends_at %}
-    {% assign registration_starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
     {% assign registration_ends_at = product.metafields.accentuate.starts_at | date: '%s' %}
     {% assign starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
     {% assign ends_at = product.metafields.accentuate.ends_at | date: '%s' %}
@@ -49,10 +47,13 @@
   {% if todays_date > ends_at %}
     {% capture button_label %}{{"snippets.add_to_cart_container.past_btn.text" | t }}{% endcapture %}
     {% assign button_disabled = true %}
+  {% elsif todays_date < registration_starts_at %}
+    {% capture button_label %}{{"snippets.add_to_cart_container.upcoming_btn.text" | t }}{% endcapture %}
+    {% assign button_disabled = true %}
   {% elsif todays_date > registration_ends_at %}
     {% capture button_label %}{{"snippets.add_to_cart_container.registration_closed_btn.text" | t }}{% endcapture %}
     {% assign button_disabled = true %}
-  {% elsif todays_date < starts_at and current_variant.available != true %}
+  {% elsif todays_date < registration_ends_at and current_variant.available != true %}
     {% capture button_label %}{{"snippets.add_to_cart_container.sold_out_btn.text" | t }}{% endcapture %}
     {% assign button_disabled = true %}
   {% endif %}

--- a/theme/snippets/add-to-cart-container.liquid
+++ b/theme/snippets/add-to-cart-container.liquid
@@ -20,22 +20,36 @@
 
   {% if lowercase_product_type == "course" %}
     {% assign sessions_sorted = bookings_metafields.sessions | sort: 'starts_at' %}
+    {% assign registration_starts_at = sessions_sorted.first.starts_at | date: '%s' %}
+    {% assign registration_ends_at = sessions_sorted.first.starts_at | date: '%s' %}
     {% assign starts_at = sessions_sorted.first.starts_at | date: '%s' %}
     {% assign ends_at = sessions_sorted.last.ends_at | date: '%s' %}
   {% elsif lowercase_product_type == "event" %}
+    {% assign registration_starts_at = bookings_metafields.starts_at | date: '%s' %}
+    {% assign registration_ends_at = bookings_metafields.starts_at | date: '%s' %}
     {% assign starts_at = bookings_metafields.starts_at | date: '%s' %}
     {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
   {% endif %}
 
   {% if product.metafields.accentuate.starts_at and product.metafields.accentuate.ends_at %}
+    {% assign registration_starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
+    {% assign registration_ends_at = product.metafields.accentuate.starts_at | date: '%s' %}
     {% assign starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
     {% assign ends_at = product.metafields.accentuate.ends_at | date: '%s' %}
+  {% endif %}
+
+  {% if product.metafields.accentuate.registration_starts_at %}
+    {% assign registration_starts_at = product.metafields.accentuate.registration_starts_at | date: '%s' %}
+  {% endif %}
+
+  {% if product.metafields.accentuate.registration_ends_at %}
+    {% assign registration_ends_at = product.metafields.accentuate.registration_ends_at | date: '%s' %}
   {% endif %}
 
   {% if todays_date > ends_at %}
     {% capture button_label %}{{"snippets.add_to_cart_container.past_btn.text" | t }}{% endcapture %}
     {% assign button_disabled = true %}
-  {% elsif todays_date > starts_at %}
+  {% elsif todays_date > registration_ends_at %}
     {% capture button_label %}{{"snippets.add_to_cart_container.registration_closed_btn.text" | t }}{% endcapture %}
     {% assign button_disabled = true %}
   {% elsif todays_date < starts_at and current_variant.available != true %}

--- a/theme/snippets/product-registration-state.liquid
+++ b/theme/snippets/product-registration-state.liquid
@@ -10,26 +10,19 @@
 
 {% if product_type == "course" %}
   {% assign sessions_sorted = bookings_metafields.sessions | sort: 'starts_at' %}
-  {% assign registration_starts_at = sessions_sorted.first.starts_at | date: '%s' %}
   {% assign registration_ends_at = sessions_sorted.first.starts_at | date: '%s' %}
   {% assign starts_at = sessions_sorted.first.starts_at | date: '%s' %}
   {% assign ends_at = sessions_sorted.last.ends_at | date: '%s' %}
 {% elsif product_type == "event" %}
-  {% assign registration_starts_at = bookings_metafields.starts_at | date: '%s' %}
   {% assign registration_ends_at = bookings_metafields.starts_at | date: '%s' %}
   {% assign starts_at = bookings_metafields.starts_at | date: '%s' %}
   {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
 {% endif %}
 
 {% if product.metafields.accentuate.starts_at and product.metafields.accentuate.ends_at %}
-  {% assign registration_starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
   {% assign registration_ends_at = product.metafields.accentuate.starts_at | date: '%s' %}
   {% assign starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
   {% assign ends_at = product.metafields.accentuate.ends_at | date: '%s' %}
-{% endif %}
-
-{% if product.metafields.accentuate.registration_starts_at %}
-  {% assign registration_starts_at = product.metafields.accentuate.registration_starts_at | date: '%s' %}
 {% endif %}
 
 {% if product.metafields.accentuate.registration_ends_at %}
@@ -40,7 +33,7 @@
   {% assign registration_state = 'snippets.product_registration_state.past' | t %}
 {% elsif todays_date > registration_ends_at %}
   {% assign registration_state = 'snippets.product_registration_state.registration_closed' | t %}
-{% elsif todays_date < starts_at and current_variant.available != true %}
+{% elsif todays_date < registration_ends_at and current_variant.available != true %}
   {% assign registration_state = 'snippets.product_registration_state.sold_out' | t %}
 {% endif %}
 

--- a/theme/snippets/product-registration-state.liquid
+++ b/theme/snippets/product-registration-state.liquid
@@ -10,21 +10,35 @@
 
 {% if product_type == "course" %}
   {% assign sessions_sorted = bookings_metafields.sessions | sort: 'starts_at' %}
+  {% assign registration_starts_at = sessions_sorted.first.starts_at | date: '%s' %}
+  {% assign registration_ends_at = sessions_sorted.first.starts_at | date: '%s' %}
   {% assign starts_at = sessions_sorted.first.starts_at | date: '%s' %}
   {% assign ends_at = sessions_sorted.last.ends_at | date: '%s' %}
 {% elsif product_type == "event" %}
+  {% assign registration_starts_at = bookings_metafields.starts_at | date: '%s' %}
+  {% assign registration_ends_at = bookings_metafields.starts_at | date: '%s' %}
   {% assign starts_at = bookings_metafields.starts_at | date: '%s' %}
   {% assign ends_at = bookings_metafields.ends_at | date: '%s' %}
 {% endif %}
 
 {% if product.metafields.accentuate.starts_at and product.metafields.accentuate.ends_at %}
+  {% assign registration_starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
+  {% assign registration_ends_at = product.metafields.accentuate.starts_at | date: '%s' %}
   {% assign starts_at = product.metafields.accentuate.starts_at | date: '%s' %}
   {% assign ends_at = product.metafields.accentuate.ends_at | date: '%s' %}
 {% endif %}
 
+{% if product.metafields.accentuate.registration_starts_at %}
+  {% assign registration_starts_at = product.metafields.accentuate.registration_starts_at | date: '%s' %}
+{% endif %}
+
+{% if product.metafields.accentuate.registration_ends_at %}
+  {% assign registration_ends_at = product.metafields.accentuate.registration_ends_at | date: '%s' %}
+{% endif %}
+
 {% if todays_date > ends_at %}
   {% assign registration_state = 'snippets.product_registration_state.past' | t %}
-{% elsif todays_date > starts_at %}
+{% elsif todays_date > registration_ends_at %}
   {% assign registration_state = 'snippets.product_registration_state.registration_closed' | t %}
 {% elsif todays_date < starts_at and current_variant.available != true %}
   {% assign registration_state = 'snippets.product_registration_state.sold_out' | t %}


### PR DESCRIPTION
### Description

Adds `registration_starts_at` and `registration_ends_at` fields to Accentuate and the accompanying logic to `product-registration-state.liquid` snippet and `add-to-cart-container.liquid` snippet.

If the `registration_starts_at` and `registration_ends_at` are empty, `registration_starts_at` will default to `todays_date` and `registration_ends_at` will default to `starts_at`.

`registration_starts_at` is not used in `product-registration-state.liquid` because what is rendered on the grid item does not change whether registration has started or not. It will stay just say 'UPCOMING' or the actual price.

The new complete logic in `add-to-cart-container.liquid` is:

```
todays_date > ends_at: PAST
todays_date < registration_starts_at: UPCOMING
todays_date > registration_ends_at: REGISTRATION CLOSED
todays_date < registration_ends_at and !available: SOLD OUT
```

### Type(s) of changes

- [x] Update to an existing feature

### Motivation for PR

https://twist.com/a/133876/ch/376069/t/3338029/

### How Has This Been Tested?

Tested by adding datetimes to the fields and ensuring correct state still gets rendered. Also on this preview theme, the Creative Coding Playground product has a `registration_starts_at` date tomorrow so it should show upcoming on the product page add to cart button. Similarly, the All about love collective reading product has a `registration_ends_at` date that matches the final session so it should still show upcoming on it's grid item and add to cart on the button.

Preview theme: https://izvjqt1swh5xrhfu-52674822324.shopifypreview.com

### Applicable screenshots:

**UPCOMING is on the disabled add to cart button if registration start date happens later**
<img width="1184" alt="Screen Shot 2022-03-23 at 10 26 26 AM" src="https://user-images.githubusercontent.com/14059589/159731414-81c4e16a-38bc-49e4-9901-d6ddd605a444.png">

### Follow-up PR

Could followup with a PR if we want different copy.
