### PR TITLE
Add collections subnav to collection template

### DIFF
--- a/theme/snippets/nav.liquid
+++ b/theme/snippets/nav.liquid
@@ -9,7 +9,7 @@
     <a data-logo-text class="Nav__button flex items-center justify-center lowercase logo radius-xs nav-button-padding--lowercase {% if request.path == '/' %} Nav__button--active" {% endif %}" href="/" aria-label="{{ 'snippets.nav.links.index_link.aria_label' | t }}"><span>{{ 'snippets.nav.links.index_link.text' | t }}</span></a>
     <span class="mx_75">{{ 'snippets.nav.hyphen' | t }}</span>
     {% for link in linklists.main-menu.links %}
-      <a class="Nav__button radius-xs nav-button-padding mr_75 {% if request.path == link.url %} Nav__button--active {% endif %}" href="{{ link.url }}">{{ link.title }}</a>
+      <a class="Nav__button radius-xs nav-button-padding mr_75 {% if link.active or link.child_active %} Nav__button--active {% endif %}" href="{{ link.url }}">{{ link.title }}</a>
     {% endfor %}
   </div>
   {% render 'nav-cart' %}

--- a/theme/styles/_snippets.scss
+++ b/theme/styles/_snippets.scss
@@ -16,6 +16,7 @@
 @import 'snippets/email-subscribe';
 @import 'snippets/product-vendor';
 @import 'snippets/collection-links';
+@import 'snippets/collection-subnav';
 @import 'snippets/background-face';
 @import 'snippets/image-caption-module';
 @import 'snippets/cart-empty';

--- a/theme/styles/snippets/collection-subnav.scss
+++ b/theme/styles/snippets/collection-subnav.scss
@@ -1,0 +1,48 @@
+.CollectionSubnav {
+  &__tabs {
+    top: $nav-height;
+    background: color('white');
+
+    @include media('md-up') {
+      top: $nav-height-md;
+    }
+
+    @include media('lg-xl-up') {
+      top: $nav-height-lg-xl;
+    }
+
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+
+    /* Chrome and Safari */
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  &__button {
+    @extend %transition-short;
+    margin-right: 1.5rem;
+    border: 1px solid color('transparent');
+    text-transform: uppercase;
+    white-space: nowrap;
+
+    font-size: 1.875rem;
+    line-height: 1.6875rem;
+
+    @include media('lg-xl-up') {
+      font-size: 3.125rem;
+      line-height: 2.8125rem;
+      margin-right: 2rem;
+    }
+
+    &:last-child {
+      margin-right: 0;
+    }
+
+    &:hover,
+    &--active {
+      border: 1px solid color('black');
+    }
+  }
+}

--- a/theme/styles/snippets/collection-subnav.scss
+++ b/theme/styles/snippets/collection-subnav.scss
@@ -2,6 +2,7 @@
   &__tabs {
     top: $nav-height;
     background: color('white');
+    row-gap: 0.5rem;
 
     @include media('md-up') {
       top: $nav-height-md;

--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -1,23 +1,35 @@
 {% assign show_featured_product =
 collection.metafields.accentuate.show_featured_product %}
+{% assign active_links = linklists.main-menu.links | where_exp: "levels > 0" %}
 
-<nav
-  data-nav
-  class="CollectionSubnav__tabs overflow-x-scroll border-top-black border-bottom-black uppercase sans-serif sticky py_5 px_625 md:px_75 text-nav bg-color-white w100 z-nav flex flex-row items-center"
->
-  {% for link in linklists.shop-collections-menu.links %}
-    {% if link.handle == collection.handle %}
-    {% assign sub_links = link.links %}
-    {% for sub_link in sub_links %}
-    <a
-      class="CollectionSubnav__button radius-xs nav-button-padding {% if forloop.last == false %} mr_75 {% endif %} {% if collection.handle == link.handle %} CollectionSubnav__button--active {% endif %}"
-      href="{{ sub_link.url }}">
-      {{ sub_link.title }}
-    </a>
-    {% endfor %}
+{% assign display_subnav = false %}
+
+{% for link in linklists.main-menu.links %}
+  {% if link.active or link.child_active %}
+    {% if link.levels > 0 %}
+      {% assign display_subnav = true %}
     {% endif %}
-  {% endfor %}
-</nav>
+  {% endif %}
+{% endfor %}
+
+{% if display_subnav %}
+  <nav
+    data-nav
+    class="CollectionSubnav__tabs flex-wrap border-top-black uppercase sans-serif sticky py_5 px_625 md:px_75 text-nav bg-color-white w100 z-nav flex flex-row items-center"
+  >
+    {% for link in linklists.main-menu.links %}
+      {% if link.active or link.child_active %}
+        {% for child_link in link.links %}
+        <a
+          class="CollectionSubnav__button radius-xs nav-button-padding {% if forloop.last == false %} mr_75 {% endif %} {% if child_link.active %} CollectionSubnav__button--active {% endif %}"
+          href="{{ child_link.url }}">
+          {{ child_link.title }}
+        </a>
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+  </nav>
+{% endif %}
 
 <h1 class="safe-visibility-hidden">{{ collection.title }}</h1>
 <div

--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -5,12 +5,17 @@ collection.metafields.accentuate.show_featured_product %}
   data-nav
   class="CollectionSubnav__tabs overflow-x-scroll border-top-black border-bottom-black uppercase sans-serif sticky py_5 px_625 md:px_75 text-nav bg-color-white w100 z-nav flex flex-row items-center"
 >
-  {% for link in linklists.collections-menu.links %}
-  <a
-    class="CollectionSubnav__button radius-xs nav-button-padding {% if forloop.last == false %} mr_75 {% endif %} {% if request.path == link.url %} CollectionSubnav__button--active {% endif %}"
-    href="{{ link.url }}"
-    >{{ link.title }}</a
-  >
+  {% for link in linklists.shop-collections-menu.links %}
+    {% if link.handle == collection.handle %}
+    {% assign sub_links = link.links %}
+    {% for sub_link in sub_links %}
+    <a
+      class="CollectionSubnav__button radius-xs nav-button-padding {% if forloop.last == false %} mr_75 {% endif %} {% if collection.handle == link.handle %} CollectionSubnav__button--active {% endif %}"
+      href="{{ sub_link.url }}">
+      {{ sub_link.title }}
+    </a>
+    {% endfor %}
+    {% endif %}
   {% endfor %}
 </nav>
 

--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -1,12 +1,27 @@
-{% assign show_featured_product = collection.metafields.accentuate.show_featured_product %}
+{% assign show_featured_product =
+collection.metafields.accentuate.show_featured_product %}
+
+<nav
+  data-nav
+  class="CollectionSubnav__tabs overflow-x-scroll border-top-black border-bottom-black uppercase sans-serif sticky py_5 px_625 md:px_75 text-nav bg-color-white w100 z-nav flex flex-row items-center"
+>
+  {% for link in linklists.collections-menu.links %}
+  <a
+    class="CollectionSubnav__button radius-xs nav-button-padding {% if forloop.last == false %} mr_75 {% endif %} {% if request.path == link.url %} CollectionSubnav__button--active {% endif %}"
+    href="{{ link.url }}"
+    >{{ link.title }}</a
+  >
+  {% endfor %}
+</nav>
 
 <h1 class="safe-visibility-hidden">{{ collection.title }}</h1>
-<div class="grid {% if show_featured_product %} grid--style-first-cell-enlarged  {% endif %}">
+<div
+  class="grid {% if show_featured_product %} grid--style-first-cell-enlarged {% endif %}"
+>
   <!-- this liquid logic allows us to show more than 50 products in a collection page without pagination -->
   <!-- 1000 is an arbitrary large number used so we won't run into a limit in the future -->
-  {% paginate collection.products by 1000 %}
-    {% for product in collection.products %}
-      {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}  
-    {% endfor %}
-  {% endpaginate %}
+  {% paginate collection.products by 1000 %} {% for product in
+  collection.products %} {% render 'product-grid-item', current_product:
+  product, show_featured_product: show_featured_product %} {% endfor %} {%
+  endpaginate %}
 </div>

--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -1,14 +1,12 @@
 {% assign show_featured_product =
 collection.metafields.accentuate.show_featured_product %}
-{% assign active_links = linklists.main-menu.links | where_exp: "levels > 0" %}
 
 {% assign display_subnav = false %}
 
+{% comment %} Do not show subnav if the active link has no children. {% endcomment %}
 {% for link in linklists.main-menu.links %}
-  {% if link.active or link.child_active %}
-    {% if link.levels > 0 %}
-      {% assign display_subnav = true %}
-    {% endif %}
+  {% if link.active or link.child_active and link.levels > 0 %}
+    {% assign display_subnav = true %}
   {% endif %}
 {% endfor %}
 
@@ -18,6 +16,7 @@ collection.metafields.accentuate.show_featured_product %}
     class="CollectionSubnav__tabs flex-wrap border-top-black uppercase sans-serif sticky py_5 px_625 md:px_75 text-nav bg-color-white w100 z-nav flex flex-row items-center"
   >
     {% for link in linklists.main-menu.links %}
+      {% comment %} If the current link or its parent are active. {% endcomment %}
       {% if link.active or link.child_active %}
         {% for child_link in link.links %}
         <a
@@ -32,13 +31,15 @@ collection.metafields.accentuate.show_featured_product %}
 {% endif %}
 
 <h1 class="safe-visibility-hidden">{{ collection.title }}</h1>
+
 <div
   class="grid {% if show_featured_product %} grid--style-first-cell-enlarged {% endif %}"
 >
   <!-- this liquid logic allows us to show more than 50 products in a collection page without pagination -->
   <!-- 1000 is an arbitrary large number used so we won't run into a limit in the future -->
-  {% paginate collection.products by 1000 %} {% for product in
-  collection.products %} {% render 'product-grid-item', current_product:
-  product, show_featured_product: show_featured_product %} {% endfor %} {%
-  endpaginate %}
+  {% paginate collection.products by 1000 %}
+    {% for product in collection.products %}
+      {% render 'product-grid-item', current_product: product, show_featured_product: show_featured_product %}
+    {% endfor %}
+  {% endpaginate %}
 </div>

--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -1,5 +1,4 @@
-{% assign show_featured_product =
-collection.metafields.accentuate.show_featured_product %}
+{% assign show_featured_product = collection.metafields.accentuate.show_featured_product %}
 
 {% assign display_subnav = false %}
 
@@ -32,9 +31,7 @@ collection.metafields.accentuate.show_featured_product %}
 
 <h1 class="safe-visibility-hidden">{{ collection.title }}</h1>
 
-<div
-  class="grid {% if show_featured_product %} grid--style-first-cell-enlarged {% endif %}"
->
+<div class="grid {% if show_featured_product %} grid--style-first-cell-enlarged {% endif %}">
   <!-- this liquid logic allows us to show more than 50 products in a collection page without pagination -->
   <!-- 1000 is an arbitrary large number used so we won't run into a limit in the future -->
   {% paginate collection.products by 1000 %}


### PR DESCRIPTION
### Description

Closes INDEX-100 by adding a sub-nav which lists links to product collections.
- This menu is configurable within the Shopify Theme navigation settings [here](https://nunu-school.myshopify.com/admin/menus/194455503028).
- When we ship this, we'll probably replace collection links in the main nav with a single `Shop` menu.

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
- https://www.notion.so/garden3d/Shopify-Collections-build-f3cb0c7df99c4514b745b1176bfb9610
- https://www.notion.so/garden3d/Shopify-Collections-Design-Review-56f363fa917849148dca24085edf8625

### How Has This Been Tested?

- Tested on desktop and mobile, Firefox and Safari. This code is modified from the PDP details subnav.

### Applicable screenshots:

- Main nav item selected, which has child links
  ![image](https://user-images.githubusercontent.com/1934813/161638883-0730be5b-e1e9-44c5-8db3-330f1b8e8b1a.png)
- Main nav item selected, and items wrap to new rows
  ![image](https://user-images.githubusercontent.com/1934813/161638918-a4742a33-5075-473e-9be1-cd0dfd25b4c1.png)
- Child collection nav item active
    ![image](https://user-images.githubusercontent.com/1934813/161638960-745230fa-5320-4a07-a508-22e5dde4b42a.png)
- Main nav item active, with no child links
  ![image](https://user-images.githubusercontent.com/1934813/161638992-03f4ee7a-d6e8-4a2f-a3b2-b7c32cb81cfa.png)



### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
