### PR TITLE
Remove sticky from subnav

### DIFF
--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -12,7 +12,7 @@
 {% if display_subnav %}
   <nav
     data-nav
-    class="CollectionSubnav__tabs flex-wrap border-top-black uppercase sans-serif sticky py_5 px_625 md:px_75 text-nav bg-color-white w100 z-description flex flex-row items-center"
+    class="CollectionSubnav__tabs flex-wrap border-top-black uppercase sans-serif py_5 px_625 md:px_75 text-nav bg-color-white w100 z-description flex flex-row items-center"
   >
     {% for link in linklists.main-menu.links %}
       {% comment %} If the current link or its parent are active. {% endcomment %}


### PR DESCRIPTION
### Description

Removes sticky property from collection subnav

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->

### Applicable screenshots:

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
